### PR TITLE
Add candle-sam3 subprocess adapter

### DIFF
--- a/backend/app/util/candle_sam3.py
+++ b/backend/app/util/candle_sam3.py
@@ -1,0 +1,263 @@
+"""
+Subprocess adapter for the candle-sam3 Rust example binary.
+
+The candle-sam3 project (https://github.com/den-sq/candle_sam3) ships a CLI
+example named ``sam3`` that runs SAM3 inference against a single image, a
+batch manifest of images, or a video clip. This module wraps the image-batch
+flow as a Python adapter so the plugin pipeline can invoke it without taking
+a direct dependency on the upstream Python ``sam3`` package.
+
+The adapter is intentionally pure: it only constructs CLI arguments, writes a
+JSON manifest, runs the binary via :func:`subprocess.run`, and parses the
+output PNG masks back into ``numpy`` arrays. All subprocess invocations go
+through :meth:`CandleSam3Adapter._run_binary` so unit tests can monkeypatch a
+single seam.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+from PIL import Image
+
+
+SAM3_BINARY_ENV = "SAM3_BINARY_PATH"
+DEFAULT_SAM3_BINARY = "/opt/candle-sam3/sam3"
+DEFAULT_MASK_FILENAME = "mask.png"
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Point:
+    """Normalized point prompt for the candle-sam3 batch manifest."""
+
+    x: float
+    y: float
+    label: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Box:
+    """Normalized box prompt (center + extent) for the candle-sam3 batch manifest."""
+
+    cx: float
+    cy: float
+    w: float
+    h: float
+    label: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Job:
+    """One image-prediction job in a candle-sam3 batch manifest."""
+
+    name: str
+    image: Path
+    prompt: Optional[str] = None
+    points: Sequence[CandleSam3Point] = ()
+    boxes: Sequence[CandleSam3Box] = ()
+
+
+class CandleSam3AdapterError(RuntimeError):
+    """Raised when the candle-sam3 binary fails or produces unexpected output."""
+
+
+class CandleSam3Adapter:
+    """
+    Wrap the candle-sam3 ``sam3`` example binary for image-batch inference.
+
+    Parameters
+    ----------
+    binary_path : str or None
+        Path to the compiled ``sam3`` binary. When ``None``, falls back to the
+        ``SAM3_BINARY_PATH`` environment variable and finally to
+        :data:`DEFAULT_SAM3_BINARY`.
+    checkpoint_path : str or None
+        Path to ``sam3.pt`` weights. Passed to ``--checkpoint``.
+    tokenizer_path : str or None
+        Path to ``tokenizer.json``. Required by candle-sam3 only when any job
+        in a batch carries a text prompt.
+    cpu : bool
+        When True, force ``--cpu`` on the underlying binary.
+    extra_args : sequence of str or None
+        Extra CLI arguments appended verbatim to every invocation.
+    """
+
+    def __init__(
+        self,
+        binary_path: Optional[str] = None,
+        checkpoint_path: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
+        cpu: bool = False,
+        extra_args: Optional[Sequence[str]] = None,
+    ):
+        resolved = binary_path or os.getenv(SAM3_BINARY_ENV) or DEFAULT_SAM3_BINARY
+        self.binary_path = Path(resolved)
+        self.checkpoint_path = Path(checkpoint_path) if checkpoint_path else None
+        self.tokenizer_path = Path(tokenizer_path) if tokenizer_path else None
+        self.cpu = bool(cpu)
+        self.extra_args = list(extra_args) if extra_args else []
+
+    def is_available(self) -> bool:
+        """Return True when the configured binary exists and is executable."""
+        try:
+            return self.binary_path.is_file() and os.access(self.binary_path, os.X_OK)
+        except OSError:
+            return False
+
+    @staticmethod
+    def normalize_xy(x: float, y: float, width: int, height: int) -> tuple[float, float]:
+        """
+        Convert pixel coordinates to normalized [0, 1] coordinates and clamp.
+
+        Parameters
+        ----------
+        x, y : float
+            Pixel coordinates (x = column, y = row).
+        width, height : int
+            Image dimensions in pixels.
+
+        Returns
+        -------
+        tuple[float, float]
+            ``(x_norm, y_norm)`` clamped to ``[0.0, 1.0]``.
+
+        Raises
+        ------
+        ValueError
+            If ``width`` or ``height`` is non-positive.
+        """
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Image dimensions must be positive (got {width}x{height})")
+        return (
+            max(0.0, min(1.0, float(x) / float(width))),
+            max(0.0, min(1.0, float(y) / float(height))),
+        )
+
+    @staticmethod
+    def build_batch_manifest(jobs: Iterable[CandleSam3Job]) -> dict:
+        """
+        Serialize an iterable of jobs into the JSON structure expected by
+        candle-sam3's ``--batch-manifest`` flag.
+
+        Boxes and points emit empty arrays when absent rather than being
+        omitted, mirroring the upstream example manifest.
+        """
+        return {
+            "jobs": [
+                {
+                    "name": job.name,
+                    "image": str(job.image),
+                    **({"prompt": job.prompt} if job.prompt else {}),
+                    "points": [
+                        {"x": p.x, "y": p.y, "label": p.label} for p in job.points
+                    ],
+                    "boxes": [
+                        {"cx": b.cx, "cy": b.cy, "w": b.w, "h": b.h, "label": b.label}
+                        for b in job.boxes
+                    ],
+                }
+                for job in jobs
+            ]
+        }
+
+    @staticmethod
+    def load_mask_png(path: Path) -> np.ndarray:
+        """
+        Load a mask PNG written by candle-sam3 as a binary ``uint8`` array
+        (0 or 255). Tolerates grayscale or RGBA inputs by collapsing to L and
+        thresholding at 127.
+        """
+        with Image.open(path) as img:
+            arr = np.asarray(img.convert("L"))
+        return (arr > 127).astype(np.uint8) * 255
+
+    def predict_image_batch(
+        self,
+        jobs: Sequence[CandleSam3Job],
+        output_dir: Path,
+        *,
+        mask_filename: str = DEFAULT_MASK_FILENAME,
+    ) -> list[np.ndarray]:
+        """
+        Run a batch of image-prediction jobs through candle-sam3 and return
+        the masks in input order.
+
+        Parameters
+        ----------
+        jobs : sequence of CandleSam3Job
+            Jobs to submit. Each job's ``name`` must be unique and filesystem-
+            safe; it is used as the per-job subdirectory under ``output_dir``.
+        output_dir : pathlib.Path
+            Directory to write the manifest and receive job outputs. Created
+            if missing.
+        mask_filename : str
+            Filename within each job subdirectory to load as the binary mask.
+            Defaults to ``mask.png``.
+
+        Returns
+        -------
+        list of numpy.ndarray
+            One ``uint8`` mask array per job, in the order of ``jobs``.
+
+        Raises
+        ------
+        CandleSam3AdapterError
+            If a job's expected mask file is missing after a successful run.
+        """
+        if not jobs:
+            return []
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest_path = output_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(self.build_batch_manifest(jobs)))
+
+        cmd = self._base_cmd() + [
+            "--batch-manifest", str(manifest_path),
+            "--output-dir", str(output_dir),
+        ]
+        self._run_binary(cmd)
+
+        masks: list[np.ndarray] = []
+        for job in jobs:
+            mask_path = output_dir / job.name / mask_filename
+            if not mask_path.is_file():
+                raise CandleSam3AdapterError(
+                    f"candle-sam3 produced no mask for job '{job.name}' at {mask_path}"
+                )
+            masks.append(self.load_mask_png(mask_path))
+        return masks
+
+    def _base_cmd(self) -> list[str]:
+        """Build the base ``sam3`` invocation independent of subcommand args."""
+        cmd: list[str] = [str(self.binary_path)]
+        if self.checkpoint_path:
+            cmd += ["--checkpoint", str(self.checkpoint_path)]
+        if self.tokenizer_path:
+            cmd += ["--tokenizer", str(self.tokenizer_path)]
+        if self.cpu:
+            cmd.append("--cpu")
+        cmd += self.extra_args
+        return cmd
+
+    def _run_binary(self, cmd: Sequence[str]) -> subprocess.CompletedProcess:
+        """
+        Execute ``sam3`` and raise on non-zero exit. The single subprocess
+        call site so tests can monkeypatch this method.
+        """
+        try:
+            return subprocess.run(
+                list(cmd), check=True, capture_output=True, text=True
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            raise CandleSam3AdapterError(
+                f"candle-sam3 binary failed (exit {exc.returncode}): {stderr}"
+            ) from exc

--- a/backend/tests/util/test_candle_sam3.py
+++ b/backend/tests/util/test_candle_sam3.py
@@ -1,0 +1,274 @@
+"""Unit tests for :mod:`backend.app.util.candle_sam3`."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from PIL import Image
+
+from backend.app.util import candle_sam3 as adapter_mod
+from backend.app.util.candle_sam3 import (
+    CandleSam3Adapter,
+    CandleSam3AdapterError,
+    CandleSam3Box,
+    CandleSam3Job,
+    CandleSam3Point,
+    DEFAULT_SAM3_BINARY,
+    SAM3_BINARY_ENV,
+)
+
+
+def _make_mask_png(path: Path, *, height: int = 4, width: int = 6, fill: int = 255) -> None:
+    arr = np.full((height, width), fill, dtype=np.uint8)
+    Image.fromarray(arr, mode="L").save(path)
+
+
+class IsAvailableTests(unittest.TestCase):
+    def test_returns_false_for_missing_binary(self):
+        adapter = CandleSam3Adapter(binary_path="/nonexistent/path/to/sam3")
+        self.assertFalse(adapter.is_available())
+
+    def test_returns_false_when_path_is_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = CandleSam3Adapter(binary_path=tmp)
+            self.assertFalse(adapter.is_available())
+
+    def test_returns_true_when_path_is_executable_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "sam3"
+            bin_path.write_text("#!/bin/sh\nexit 0\n")
+            bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            adapter = CandleSam3Adapter(binary_path=str(bin_path))
+            self.assertTrue(adapter.is_available())
+
+    def test_resolves_binary_from_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "sam3"
+            bin_path.write_text("")
+            bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR)
+            original = os.environ.get(SAM3_BINARY_ENV)
+            try:
+                os.environ[SAM3_BINARY_ENV] = str(bin_path)
+                adapter = CandleSam3Adapter()
+                self.assertEqual(adapter.binary_path, bin_path)
+            finally:
+                if original is None:
+                    os.environ.pop(SAM3_BINARY_ENV, None)
+                else:
+                    os.environ[SAM3_BINARY_ENV] = original
+
+    def test_falls_back_to_default_binary_path(self):
+        original = os.environ.pop(SAM3_BINARY_ENV, None)
+        try:
+            adapter = CandleSam3Adapter()
+            self.assertEqual(adapter.binary_path, Path(DEFAULT_SAM3_BINARY))
+        finally:
+            if original is not None:
+                os.environ[SAM3_BINARY_ENV] = original
+
+
+class NormalizeXyTests(unittest.TestCase):
+    def test_basic_division(self):
+        self.assertEqual(
+            CandleSam3Adapter.normalize_xy(50, 25, width=100, height=100),
+            (0.5, 0.25),
+        )
+
+    def test_clamps_below_zero(self):
+        x, y = CandleSam3Adapter.normalize_xy(-10, -5, width=100, height=100)
+        self.assertEqual((x, y), (0.0, 0.0))
+
+    def test_clamps_above_one(self):
+        x, y = CandleSam3Adapter.normalize_xy(200, 300, width=100, height=100)
+        self.assertEqual((x, y), (1.0, 1.0))
+
+    def test_rejects_non_positive_dimensions(self):
+        with self.assertRaises(ValueError):
+            CandleSam3Adapter.normalize_xy(1, 1, width=0, height=10)
+        with self.assertRaises(ValueError):
+            CandleSam3Adapter.normalize_xy(1, 1, width=10, height=-1)
+
+
+class BuildBatchManifestTests(unittest.TestCase):
+    def test_minimal_prompt_only_job(self):
+        job = CandleSam3Job(name="alpha", image=Path("/tmp/a.png"), prompt="cat")
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertEqual(
+            manifest,
+            {
+                "jobs": [
+                    {
+                        "name": "alpha",
+                        "image": "/tmp/a.png",
+                        "prompt": "cat",
+                        "points": [],
+                        "boxes": [],
+                    }
+                ]
+            },
+        )
+
+    def test_omits_prompt_when_none(self):
+        job = CandleSam3Job(name="bare", image=Path("/tmp/b.png"))
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertNotIn("prompt", manifest["jobs"][0])
+
+    def test_geometry_serialization_order_and_defaults(self):
+        job = CandleSam3Job(
+            name="geo",
+            image=Path("/tmp/c.png"),
+            points=[CandleSam3Point(x=0.1, y=0.2), CandleSam3Point(x=0.3, y=0.4, label=0)],
+            boxes=[CandleSam3Box(cx=0.5, cy=0.5, w=0.2, h=0.2)],
+        )
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertEqual(
+            manifest["jobs"][0]["points"],
+            [
+                {"x": 0.1, "y": 0.2, "label": 1},
+                {"x": 0.3, "y": 0.4, "label": 0},
+            ],
+        )
+        self.assertEqual(
+            manifest["jobs"][0]["boxes"],
+            [{"cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2, "label": 1}],
+        )
+
+
+class LoadMaskPngTests(unittest.TestCase):
+    def test_binarizes_grayscale_at_127(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mask.png"
+            arr = np.array([[0, 64, 127], [128, 200, 255]], dtype=np.uint8)
+            Image.fromarray(arr, mode="L").save(path)
+            out = adapter_mod.CandleSam3Adapter.load_mask_png(path)
+            np.testing.assert_array_equal(
+                out,
+                np.array([[0, 0, 0], [255, 255, 255]], dtype=np.uint8),
+            )
+
+    def test_collapses_rgba_to_luminance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mask.png"
+            arr = np.zeros((3, 3, 4), dtype=np.uint8)
+            arr[..., :3] = 255
+            arr[..., 3] = 255
+            Image.fromarray(arr, mode="RGBA").save(path)
+            out = adapter_mod.CandleSam3Adapter.load_mask_png(path)
+            np.testing.assert_array_equal(out, np.full((3, 3), 255, dtype=np.uint8))
+
+
+class PredictImageBatchTests(unittest.TestCase):
+    def test_empty_jobs_returns_empty_list_without_running_binary(self):
+        captured: list = []
+        adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+        adapter._run_binary = lambda cmd: captured.append(cmd)  # type: ignore[assignment]
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(adapter.predict_image_batch([], Path(tmp)), [])
+        self.assertEqual(captured, [])
+
+    def test_runs_binary_with_expected_args_and_returns_masks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "out"
+            jobs = [
+                CandleSam3Job(name="job1", image=Path("/img/1.png"), prompt="x"),
+                CandleSam3Job(name="job2", image=Path("/img/2.png"), prompt="y"),
+            ]
+
+            captured: list[Sequence[str]] = []
+
+            def fake_run(cmd: Sequence[str]):
+                captured.append(list(cmd))
+                for job in jobs:
+                    (output_dir / job.name).mkdir(parents=True, exist_ok=True)
+                    _make_mask_png(output_dir / job.name / "mask.png")
+
+            adapter = CandleSam3Adapter(
+                binary_path="/fake/sam3",
+                checkpoint_path="/fake/sam3.pt",
+                tokenizer_path="/fake/tokenizer.json",
+                cpu=True,
+            )
+            adapter._run_binary = fake_run  # type: ignore[assignment]
+            masks = adapter.predict_image_batch(jobs, output_dir)
+
+            self.assertEqual(len(masks), 2)
+            for mask in masks:
+                self.assertEqual(mask.dtype, np.uint8)
+                self.assertEqual(set(np.unique(mask).tolist()), {255})
+
+            self.assertEqual(len(captured), 1)
+            cmd = captured[0]
+            self.assertEqual(cmd[0], "/fake/sam3")
+            self.assertIn("--checkpoint", cmd)
+            self.assertIn("/fake/sam3.pt", cmd)
+            self.assertIn("--tokenizer", cmd)
+            self.assertIn("/fake/tokenizer.json", cmd)
+            self.assertIn("--cpu", cmd)
+            self.assertIn("--batch-manifest", cmd)
+            self.assertIn("--output-dir", cmd)
+            self.assertEqual(cmd[cmd.index("--output-dir") + 1], str(output_dir))
+
+            manifest_path = output_dir / "manifest.json"
+            self.assertTrue(manifest_path.is_file())
+            self.assertEqual(
+                json.loads(manifest_path.read_text())["jobs"][0]["name"], "job1"
+            )
+
+    def test_missing_mask_raises_adapter_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "out"
+            jobs = [CandleSam3Job(name="solo", image=Path("/img.png"), prompt="z")]
+            output_dir.mkdir(parents=True)
+            (output_dir / "solo").mkdir()
+            adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+            adapter._run_binary = lambda cmd: None  # type: ignore[assignment]
+            with self.assertRaises(CandleSam3AdapterError):
+                adapter.predict_image_batch(jobs, output_dir)
+
+    def test_omits_optional_flags_when_unset(self):
+        captured: list[Sequence[str]] = []
+
+        def fake_run(cmd: Sequence[str]):
+            captured.append(list(cmd))
+            (output_dir / "only").mkdir(parents=True, exist_ok=True)
+            _make_mask_png(output_dir / "only" / "mask.png")
+
+        adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+        adapter._run_binary = fake_run  # type: ignore[assignment]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            adapter.predict_image_batch(
+                [CandleSam3Job(name="only", image=Path("/x.png"), prompt="z")],
+                output_dir,
+            )
+
+        cmd = captured[0]
+        self.assertNotIn("--checkpoint", cmd)
+        self.assertNotIn("--tokenizer", cmd)
+        self.assertNotIn("--cpu", cmd)
+
+
+class RunBinaryTests(unittest.TestCase):
+    def test_called_process_error_raises_adapter_error(self):
+        adapter = CandleSam3Adapter(binary_path="/bin/false")
+        with self.assertRaises(CandleSam3AdapterError) as cm:
+            adapter._run_binary(["/bin/false"])
+        self.assertIn("candle-sam3 binary failed", str(cm.exception))
+
+    def test_successful_invocation_returns_completed_process(self):
+        adapter = CandleSam3Adapter(binary_path="/bin/true")
+        result = adapter._run_binary(["/bin/echo", "hello"])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("hello", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `backend/app/util/candle_sam3.py`: a pure subprocess adapter around the `candle-sam3` Rust example binary (`sam3`).
- `CandleSam3Adapter` wraps `--batch-manifest` image-batch mode; `predict_image_batch` builds a JSON manifest, invokes the binary via `_run_binary` (the single mockable seam), and reads per-job `mask.png` outputs back as numpy arrays.
- Includes `normalize_xy` (pixel→[0,1]), `build_batch_manifest`, `load_mask_png`, `CandleSam3Point`, `CandleSam3Box`, `CandleSam3Job` data classes.
- No pipeline wiring in this PR; no Docker change.

## Test plan

- [ ] `backend/tests/util/test_candle_sam3.py` — 20 unit tests covering all public methods; all pass with `pytest numpy pillow tifffile` only (no PyTorch required)
- [ ] All tests run in Docker: `docker run --rm -v $PWD:/repo -w /repo python:3.10-slim bash -c "pip install pytest numpy pillow tifffile && python -m pytest backend/tests/util/test_candle_sam3.py -v"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)