### PR TITLE
Wire candle-sam3 as a VideoPredictor backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 
 from .pipeline.pipeline import run_pipeline
 from .util import config, network
+from .util.candle_sam3 import CandleSam3Adapter
 from .util.util import DownloadRequest, ProcessRequest
 
 app = FastAPI()
@@ -87,6 +88,11 @@ async def get_model_status():
     for model_name in tracked_models:
         checkpoint_path = os.path.join(config.CHECKPOINT_DIR, f"{model_name}.pt")
         statuses[model_name] = os.path.isfile(checkpoint_path)
+
+    sam3_checkpoint = os.path.join(config.CHECKPOINT_DIR, "sam3.pt")
+    statuses["candle_sam3"] = (
+        os.path.isfile(sam3_checkpoint) and CandleSam3Adapter().is_available()
+    )
 
     return {
         "checkpoint_dir": config.CHECKPOINT_DIR,

--- a/backend/app/pipeline/pipeline.py
+++ b/backend/app/pipeline/pipeline.py
@@ -187,6 +187,51 @@ async def run_candle_sam3_image_predictor(
         await asyncio.sleep(0.001)
 
 
+async def run_candle_sam3_video_predictor(
+    adapter: CandleSam3Adapter,
+    volume_folder: Path,
+    annotation_points: np.ndarray,
+    input_shape: tuple[int, int, int],
+    result_stack: np.ndarray,
+    job_id: str,
+):
+    """
+    Drive candle-sam3 video prediction over the JPEG frames in ``volume_folder``.
+
+    Seeds object 1 on frame 0 using the first annotation point and propagates
+    forward through all frames. Masks are read from the binary's
+    ``masks/frame_XXXXXX_obj_000001.png`` output pattern.
+
+    Note: candle-sam3 video mode seeds a single object on frame 0 only;
+    multi-frame annotation seeding is not supported by the upstream CLI.
+    """
+    height, width = int(input_shape[1]), int(input_shape[2])
+
+    seed_pt = _annotation_point_for_frame(annotation_points, 0)[0]
+    x_norm, y_norm = CandleSam3Adapter.normalize_xy(
+        float(seed_pt[0]), float(seed_pt[1]), width=width, height=height
+    )
+    seed = CandleSam3Point(x=x_norm, y=y_norm, label=1)
+
+    output_dir = volume_folder.parent / f"{volume_folder.name}_candle_sam3_video_out"
+    masks = adapter.predict_video(
+        video_path=volume_folder,
+        seed_point=seed,
+        output_dir=output_dir,
+        num_frames=input_shape[0],
+    )
+
+    for i, mask in enumerate(masks):
+        if mask.shape != (height, width):
+            mask = np.asarray(
+                PILImage.fromarray(mask).resize((width, height), resample=PILImage.NEAREST)
+            )
+        result_stack[i] = mask
+        pct = int(((i + 1) / input_shape[0]) * 100)
+        update_step(job_id, 1, pct)
+        await asyncio.sleep(0.001)
+
+
 async def run_image_predictor(
     predictor,
     volume_folder: Path,
@@ -312,7 +357,16 @@ async def run_pipeline(job_id: str, host_path: str, output_path: str, model_type
 
         result_stack = np.zeros(input_shape, dtype=np.uint8)
 
-        if use_candle_sam3:
+        if use_candle_sam3 and predictor_type == "VideoPredictor":
+            await run_candle_sam3_video_predictor(
+                adapter=predictor,
+                volume_folder=volume_folder,
+                annotation_points=annotation_points,
+                input_shape=input_shape,
+                result_stack=result_stack,
+                job_id=job_id,
+            )
+        elif use_candle_sam3:
             await run_candle_sam3_image_predictor(
                 adapter=predictor,
                 volume_folder=volume_folder,

--- a/backend/app/pipeline/pipeline.py
+++ b/backend/app/pipeline/pipeline.py
@@ -10,7 +10,10 @@ import traceback
 import numpy as np
 import tifffile as tf
 
+from PIL import Image as PILImage
+
 from ..util import config
+from ..util.candle_sam3 import CandleSam3Adapter, CandleSam3Job, CandleSam3Point
 from ..util.network import copy_to_host, copy_to_volume, get_predictor
 from ..util.util import (
     _annotation_point_for_frame,
@@ -132,6 +135,58 @@ async def run_video_predictor(
         raise
 
 
+async def run_candle_sam3_image_predictor(
+    adapter: CandleSam3Adapter,
+    volume_folder: Path,
+    annotation_points: np.ndarray,
+    input_shape: tuple[int, int, int],
+    result_stack: np.ndarray,
+    job_id: str,
+):
+    """
+    Drive a candle-sam3 image-batch run for every frame in ``volume_folder``
+    using the per-frame interpolated annotation point as the geometry prompt.
+
+    Each frame becomes one job in the batch manifest. The result mask is
+    binarized, resized to ``(H, W)`` if needed, and written into
+    ``result_stack`` at the matching index.
+    """
+    frame_paths = sorted(volume_folder.iterdir())
+    if len(frame_paths) != input_shape[0]:
+        raise RuntimeError(
+            f"Frame count mismatch: expected {input_shape[0]} from input_shape, "
+            f"found {len(frame_paths)} files in {volume_folder}"
+        )
+    height, width = int(input_shape[1]), int(input_shape[2])
+
+    jobs: list[CandleSam3Job] = []
+    for i, img_path in enumerate(frame_paths):
+        pt = _annotation_point_for_frame(annotation_points, i)[0]
+        x_norm, y_norm = CandleSam3Adapter.normalize_xy(
+            float(pt[0]), float(pt[1]), width=width, height=height
+        )
+        jobs.append(
+            CandleSam3Job(
+                name=f"frame_{i:06d}",
+                image=img_path,
+                points=[CandleSam3Point(x=x_norm, y=y_norm, label=1)],
+            )
+        )
+
+    output_dir = volume_folder.parent / f"{volume_folder.name}_candle_sam3_out"
+    masks = adapter.predict_image_batch(jobs, output_dir)
+
+    for i, mask in enumerate(masks):
+        if mask.shape != (height, width):
+            mask = np.asarray(
+                PILImage.fromarray(mask).resize((width, height), resample=PILImage.NEAREST)
+            )
+        result_stack[i] = mask
+        pct = int(((i + 1) / input_shape[0]) * 100)
+        update_step(job_id, 1, pct)
+        await asyncio.sleep(0.001)
+
+
 async def run_image_predictor(
     predictor,
     volume_folder: Path,
@@ -233,6 +288,7 @@ async def run_pipeline(job_id: str, host_path: str, output_path: str, model_type
         else:
             print(f"Loaded {len(annotation_points)} annotation points from TIFF metadata.")
 
+        use_candle_sam3 = model_type == "candle_sam3"
         with Pool(8) as pool:
             if predictor_type == "ImagePredictor":
                 pool.starmap(downsample, convert_args)
@@ -256,7 +312,16 @@ async def run_pipeline(job_id: str, host_path: str, output_path: str, model_type
 
         result_stack = np.zeros(input_shape, dtype=np.uint8)
 
-        if predictor_type == "VideoPredictor":
+        if use_candle_sam3:
+            await run_candle_sam3_image_predictor(
+                adapter=predictor,
+                volume_folder=volume_folder,
+                annotation_points=annotation_points,
+                input_shape=input_shape,
+                result_stack=result_stack,
+                job_id=job_id,
+            )
+        elif predictor_type == "VideoPredictor":
             await run_video_predictor(
                 predictor=predictor,
                 volume_folder=volume_folder,

--- a/backend/app/util/candle_sam3.py
+++ b/backend/app/util/candle_sam3.py
@@ -1,0 +1,263 @@
+"""
+Subprocess adapter for the candle-sam3 Rust example binary.
+
+The candle-sam3 project (https://github.com/den-sq/candle_sam3) ships a CLI
+example named ``sam3`` that runs SAM3 inference against a single image, a
+batch manifest of images, or a video clip. This module wraps the image-batch
+flow as a Python adapter so the plugin pipeline can invoke it without taking
+a direct dependency on the upstream Python ``sam3`` package.
+
+The adapter is intentionally pure: it only constructs CLI arguments, writes a
+JSON manifest, runs the binary via :func:`subprocess.run`, and parses the
+output PNG masks back into ``numpy`` arrays. All subprocess invocations go
+through :meth:`CandleSam3Adapter._run_binary` so unit tests can monkeypatch a
+single seam.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+from PIL import Image
+
+
+SAM3_BINARY_ENV = "SAM3_BINARY_PATH"
+DEFAULT_SAM3_BINARY = "/opt/candle-sam3/sam3"
+DEFAULT_MASK_FILENAME = "mask.png"
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Point:
+    """Normalized point prompt for the candle-sam3 batch manifest."""
+
+    x: float
+    y: float
+    label: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Box:
+    """Normalized box prompt (center + extent) for the candle-sam3 batch manifest."""
+
+    cx: float
+    cy: float
+    w: float
+    h: float
+    label: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class CandleSam3Job:
+    """One image-prediction job in a candle-sam3 batch manifest."""
+
+    name: str
+    image: Path
+    prompt: Optional[str] = None
+    points: Sequence[CandleSam3Point] = ()
+    boxes: Sequence[CandleSam3Box] = ()
+
+
+class CandleSam3AdapterError(RuntimeError):
+    """Raised when the candle-sam3 binary fails or produces unexpected output."""
+
+
+class CandleSam3Adapter:
+    """
+    Wrap the candle-sam3 ``sam3`` example binary for image-batch inference.
+
+    Parameters
+    ----------
+    binary_path : str or None
+        Path to the compiled ``sam3`` binary. When ``None``, falls back to the
+        ``SAM3_BINARY_PATH`` environment variable and finally to
+        :data:`DEFAULT_SAM3_BINARY`.
+    checkpoint_path : str or None
+        Path to ``sam3.pt`` weights. Passed to ``--checkpoint``.
+    tokenizer_path : str or None
+        Path to ``tokenizer.json``. Required by candle-sam3 only when any job
+        in a batch carries a text prompt.
+    cpu : bool
+        When True, force ``--cpu`` on the underlying binary.
+    extra_args : sequence of str or None
+        Extra CLI arguments appended verbatim to every invocation.
+    """
+
+    def __init__(
+        self,
+        binary_path: Optional[str] = None,
+        checkpoint_path: Optional[str] = None,
+        tokenizer_path: Optional[str] = None,
+        cpu: bool = False,
+        extra_args: Optional[Sequence[str]] = None,
+    ):
+        resolved = binary_path or os.getenv(SAM3_BINARY_ENV) or DEFAULT_SAM3_BINARY
+        self.binary_path = Path(resolved)
+        self.checkpoint_path = Path(checkpoint_path) if checkpoint_path else None
+        self.tokenizer_path = Path(tokenizer_path) if tokenizer_path else None
+        self.cpu = bool(cpu)
+        self.extra_args = list(extra_args) if extra_args else []
+
+    def is_available(self) -> bool:
+        """Return True when the configured binary exists and is executable."""
+        try:
+            return self.binary_path.is_file() and os.access(self.binary_path, os.X_OK)
+        except OSError:
+            return False
+
+    @staticmethod
+    def normalize_xy(x: float, y: float, width: int, height: int) -> tuple[float, float]:
+        """
+        Convert pixel coordinates to normalized [0, 1] coordinates and clamp.
+
+        Parameters
+        ----------
+        x, y : float
+            Pixel coordinates (x = column, y = row).
+        width, height : int
+            Image dimensions in pixels.
+
+        Returns
+        -------
+        tuple[float, float]
+            ``(x_norm, y_norm)`` clamped to ``[0.0, 1.0]``.
+
+        Raises
+        ------
+        ValueError
+            If ``width`` or ``height`` is non-positive.
+        """
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Image dimensions must be positive (got {width}x{height})")
+        return (
+            max(0.0, min(1.0, float(x) / float(width))),
+            max(0.0, min(1.0, float(y) / float(height))),
+        )
+
+    @staticmethod
+    def build_batch_manifest(jobs: Iterable[CandleSam3Job]) -> dict:
+        """
+        Serialize an iterable of jobs into the JSON structure expected by
+        candle-sam3's ``--batch-manifest`` flag.
+
+        Boxes and points emit empty arrays when absent rather than being
+        omitted, mirroring the upstream example manifest.
+        """
+        return {
+            "jobs": [
+                {
+                    "name": job.name,
+                    "image": str(job.image),
+                    **({"prompt": job.prompt} if job.prompt else {}),
+                    "points": [
+                        {"x": p.x, "y": p.y, "label": p.label} for p in job.points
+                    ],
+                    "boxes": [
+                        {"cx": b.cx, "cy": b.cy, "w": b.w, "h": b.h, "label": b.label}
+                        for b in job.boxes
+                    ],
+                }
+                for job in jobs
+            ]
+        }
+
+    @staticmethod
+    def load_mask_png(path: Path) -> np.ndarray:
+        """
+        Load a mask PNG written by candle-sam3 as a binary ``uint8`` array
+        (0 or 255). Tolerates grayscale or RGBA inputs by collapsing to L and
+        thresholding at 127.
+        """
+        with Image.open(path) as img:
+            arr = np.asarray(img.convert("L"))
+        return (arr > 127).astype(np.uint8) * 255
+
+    def predict_image_batch(
+        self,
+        jobs: Sequence[CandleSam3Job],
+        output_dir: Path,
+        *,
+        mask_filename: str = DEFAULT_MASK_FILENAME,
+    ) -> list[np.ndarray]:
+        """
+        Run a batch of image-prediction jobs through candle-sam3 and return
+        the masks in input order.
+
+        Parameters
+        ----------
+        jobs : sequence of CandleSam3Job
+            Jobs to submit. Each job's ``name`` must be unique and filesystem-
+            safe; it is used as the per-job subdirectory under ``output_dir``.
+        output_dir : pathlib.Path
+            Directory to write the manifest and receive job outputs. Created
+            if missing.
+        mask_filename : str
+            Filename within each job subdirectory to load as the binary mask.
+            Defaults to ``mask.png``.
+
+        Returns
+        -------
+        list of numpy.ndarray
+            One ``uint8`` mask array per job, in the order of ``jobs``.
+
+        Raises
+        ------
+        CandleSam3AdapterError
+            If a job's expected mask file is missing after a successful run.
+        """
+        if not jobs:
+            return []
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        manifest_path = output_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(self.build_batch_manifest(jobs)))
+
+        cmd = self._base_cmd() + [
+            "--batch-manifest", str(manifest_path),
+            "--output-dir", str(output_dir),
+        ]
+        self._run_binary(cmd)
+
+        masks: list[np.ndarray] = []
+        for job in jobs:
+            mask_path = output_dir / job.name / mask_filename
+            if not mask_path.is_file():
+                raise CandleSam3AdapterError(
+                    f"candle-sam3 produced no mask for job '{job.name}' at {mask_path}"
+                )
+            masks.append(self.load_mask_png(mask_path))
+        return masks
+
+    def _base_cmd(self) -> list[str]:
+        """Build the base ``sam3`` invocation independent of subcommand args."""
+        cmd: list[str] = [str(self.binary_path)]
+        if self.checkpoint_path:
+            cmd += ["--checkpoint", str(self.checkpoint_path)]
+        if self.tokenizer_path:
+            cmd += ["--tokenizer", str(self.tokenizer_path)]
+        if self.cpu:
+            cmd.append("--cpu")
+        cmd += self.extra_args
+        return cmd
+
+    def _run_binary(self, cmd: Sequence[str]) -> subprocess.CompletedProcess:
+        """
+        Execute ``sam3`` and raise on non-zero exit. The single subprocess
+        call site so tests can monkeypatch this method.
+        """
+        try:
+            return subprocess.run(
+                list(cmd), check=True, capture_output=True, text=True
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            raise CandleSam3AdapterError(
+                f"candle-sam3 binary failed (exit {exc.returncode}): {stderr}"
+            ) from exc

--- a/backend/app/util/candle_sam3.py
+++ b/backend/app/util/candle_sam3.py
@@ -235,6 +235,74 @@ class CandleSam3Adapter:
             masks.append(self.load_mask_png(mask_path))
         return masks
 
+    def predict_video(
+        self,
+        video_path: Path,
+        seed_point: "CandleSam3Point",
+        output_dir: Path,
+        num_frames: int,
+        *,
+        prompt: Optional[str] = None,
+    ) -> list[np.ndarray]:
+        """
+        Run video prediction for a folder of image frames through candle-sam3.
+
+        Seeds object 1 on frame 0 with ``seed_point`` and propagates forward
+        through all ``num_frames`` frames. Returns one binary ``uint8`` mask
+        per frame in forward order.
+
+        Mask files are expected at
+        ``<output_dir>/masks/frame_XXXXXX_obj_000001.png`` — the naming
+        convention written by candle-sam3's video export path.
+
+        Parameters
+        ----------
+        video_path : Path
+            Directory of sorted image frames (JPEG/PNG) to segment.
+        seed_point : CandleSam3Point
+            Normalized [0, 1] click-point used to seed object 1 on frame 0.
+        output_dir : Path
+            Directory where candle-sam3 writes its ``masks/`` subdirectory.
+        num_frames : int
+            Expected number of output frames. Used to enumerate mask files.
+        prompt : str or None
+            Optional text prompt forwarded as ``--video-prompt``.
+
+        Returns
+        -------
+        list of numpy.ndarray
+            One ``uint8`` (0 or 255) mask array per frame.
+
+        Raises
+        ------
+        CandleSam3AdapterError
+            If the binary fails or any expected mask file is missing.
+        """
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = self._base_cmd() + [
+            "--video", str(video_path),
+            "--point", f"{seed_point.x},{seed_point.y}",
+            "--point-label", str(seed_point.label),
+            "--output-dir", str(output_dir),
+        ]
+        if prompt:
+            cmd += ["--video-prompt", prompt]
+
+        self._run_binary(cmd)
+
+        masks_dir = output_dir / "masks"
+        masks: list[np.ndarray] = []
+        for i in range(num_frames):
+            mask_path = masks_dir / f"frame_{i:06d}_obj_000001.png"
+            if not mask_path.is_file():
+                raise CandleSam3AdapterError(
+                    f"candle-sam3 produced no video mask for frame {i} at {mask_path}"
+                )
+            masks.append(self.load_mask_png(mask_path))
+        return masks
+
     def _base_cmd(self) -> list[str]:
         """Build the base ``sam3`` invocation independent of subcommand args."""
         cmd: list[str] = [str(self.binary_path)]

--- a/backend/app/util/network.py
+++ b/backend/app/util/network.py
@@ -7,6 +7,7 @@ import requests
 import torch
 
 from . import config
+from .candle_sam3 import CandleSam3Adapter
 
 
 # --- Imports for SAM2/SAM3 ---
@@ -29,10 +30,16 @@ except ImportError as ie:
     Sam3Processor = None
 
 
+def _candle_sam3_available() -> bool:
+    """Return True when the candle-sam3 binary is configured and executable."""
+    return CandleSam3Adapter().is_available()
+
+
 def models_available() -> bool:
     return (
         (build_sam2 is not None and SAM2ImagePredictor is not None)
         or (build_sam3_video_predictor is not None and Sam3Processor is not None)
+        or _candle_sam3_available()
     )
 
 
@@ -214,6 +221,31 @@ def get_predictor(model_name: str, predictor_type: str):
             )
         else:
             raise ValueError(f"Unknown predictor type: {predictor_type}")
+
+    elif model_name == "candle_sam3":
+        if predictor_type != "ImagePredictor":
+            raise ValueError(
+                f"candle_sam3 currently supports only ImagePredictor (got {predictor_type})"
+            )
+
+        sam3_checkpoint = os.path.join(config.CHECKPOINT_DIR, "sam3.pt")
+        if not os.path.isfile(sam3_checkpoint):
+            raise FileNotFoundError(
+                f"SAM3 checkpoint not found at {sam3_checkpoint}. "
+                "Please use the 'Models' section to download it with your authentication token."
+            )
+
+        adapter = CandleSam3Adapter(
+            checkpoint_path=sam3_checkpoint,
+            tokenizer_path=os.getenv("SAM3_TOKENIZER_PATH"),
+            cpu=(device == "cpu"),
+        )
+        if not adapter.is_available():
+            raise FileNotFoundError(
+                f"candle-sam3 binary not found or not executable at {adapter.binary_path}. "
+                "Set SAM3_BINARY_PATH or install the binary."
+            )
+        config.loaded_predictor = adapter
 
     elif model_name.startswith("sam3"):
         if Sam3Processor is None:

--- a/backend/app/util/network.py
+++ b/backend/app/util/network.py
@@ -223,9 +223,9 @@ def get_predictor(model_name: str, predictor_type: str):
             raise ValueError(f"Unknown predictor type: {predictor_type}")
 
     elif model_name == "candle_sam3":
-        if predictor_type != "ImagePredictor":
+        if predictor_type not in ("ImagePredictor", "VideoPredictor"):
             raise ValueError(
-                f"candle_sam3 currently supports only ImagePredictor (got {predictor_type})"
+                f"candle_sam3 supports ImagePredictor and VideoPredictor (got {predictor_type})"
             )
 
         sam3_checkpoint = os.path.join(config.CHECKPOINT_DIR, "sam3.pt")

--- a/backend/tests/pipeline/test_pipeline.py
+++ b/backend/tests/pipeline/test_pipeline.py
@@ -8,12 +8,14 @@ from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import tifffile as tf
+from PIL import Image as PILImage
 
 _TEST_VOLUME_ROOT = tempfile.mkdtemp(prefix="ouroboros-test-volume-")
 os.environ["VOLUME_MOUNT_PATH"] = _TEST_VOLUME_ROOT
 
 from backend.app.pipeline import pipeline as app_pipeline  # noqa: E402
 from backend.app.util import config as app_config  # noqa: E402
+from backend.app.util.candle_sam3 import CandleSam3Adapter  # noqa: E402
 
 
 class _FakeImagePredictor:
@@ -577,6 +579,156 @@ class PipelineTests(unittest.TestCase):
 
                 self.assertEqual(app_config.jobs["job-1"]["status"], "error")
                 self.assertEqual(app_config.jobs["job-1"]["updated_at"], 203.0)
+
+
+class _StubCandleSam3Adapter(CandleSam3Adapter):
+    def __init__(self, mask_value: int = 255):
+        super().__init__(binary_path="/fake/sam3")
+        self.mask_value = mask_value
+        self.captured_jobs = None
+
+    def _run_binary(self, cmd):
+        return None
+
+    def predict_image_batch(self, jobs, output_dir, *, mask_filename="mask.png"):
+        self.captured_jobs = list(jobs)
+        return [
+            np.full((4, 6), self.mask_value, dtype=np.uint8) for _ in self.captured_jobs
+        ]
+
+
+class CandleSam3PipelineTests(unittest.TestCase):
+    def setUp(self):
+        self.jobs_original = copy.deepcopy(app_config.jobs)
+
+    def tearDown(self):
+        app_config.jobs = self.jobs_original
+
+    def _seed_job(self, job_id="job-1"):
+        app_config.jobs[job_id] = {
+            "status": "running",
+            "steps": [
+                {"name": "Transferring", "progress": 0},
+                {"name": "Inference", "progress": 0},
+                {"name": "Saving", "progress": 0},
+            ],
+            "updated_at": 0,
+        }
+
+    def test_run_candle_sam3_image_predictor_resizes_and_writes_stack(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            volume_folder = Path(tmpdir) / "frames"
+            volume_folder.mkdir()
+            tf.imwrite(volume_folder / "000.tif", np.zeros((2, 2), dtype=np.uint8))
+            tf.imwrite(volume_folder / "001.tif", np.zeros((2, 2), dtype=np.uint8))
+
+            self._seed_job("job-1")
+            adapter = _StubCandleSam3Adapter()
+            result_stack = np.zeros((2, 3, 4), dtype=np.uint8)
+            annotation_points = np.array(
+                [[2.0, 1.0, 0.0], [2.0, 1.0, 1.0]], dtype=np.float32
+            )
+
+            asyncio.run(
+                app_pipeline.run_candle_sam3_image_predictor(
+                    adapter=adapter,
+                    volume_folder=volume_folder,
+                    annotation_points=annotation_points,
+                    input_shape=(2, 3, 4),
+                    result_stack=result_stack,
+                    job_id="job-1",
+                )
+            )
+
+            self.assertEqual(len(adapter.captured_jobs), 2)
+            np.testing.assert_array_equal(
+                result_stack[0], np.full((3, 4), 255, dtype=np.uint8)
+            )
+            np.testing.assert_array_equal(
+                result_stack[1], np.full((3, 4), 255, dtype=np.uint8)
+            )
+            self.assertEqual(app_config.jobs["job-1"]["steps"][1]["progress"], 100)
+
+            for i, job in enumerate(adapter.captured_jobs):
+                self.assertEqual(job.name, f"frame_{i:06d}")
+                self.assertEqual(len(job.points), 1)
+                self.assertAlmostEqual(job.points[0].x, 0.5, places=4)
+                self.assertAlmostEqual(job.points[0].y, 1.0 / 3.0, places=4)
+
+    def test_run_candle_sam3_image_predictor_raises_on_frame_count_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            volume_folder = Path(tmpdir) / "frames"
+            volume_folder.mkdir()
+            tf.imwrite(volume_folder / "000.tif", np.zeros((2, 2), dtype=np.uint8))
+
+            self._seed_job("job-1")
+
+            with self.assertRaises(RuntimeError) as ctx:
+                asyncio.run(
+                    app_pipeline.run_candle_sam3_image_predictor(
+                        adapter=_StubCandleSam3Adapter(),
+                        volume_folder=volume_folder,
+                        annotation_points=np.array([[1.0, 1.0, 0.0]], dtype=np.float32),
+                        input_shape=(2, 2, 2),
+                        result_stack=np.zeros((2, 2, 2), dtype=np.uint8),
+                        job_id="job-1",
+                    )
+                )
+            self.assertIn("Frame count mismatch", str(ctx.exception))
+
+    def test_run_pipeline_candle_sam3_dispatches_to_candle_runner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("backend.app.pipeline.pipeline.config.INTERNAL_VOLUME_PATH", tmpdir):
+                plugin_root = Path(tmpdir, app_config.PLUGIN_NAME)
+                plugin_root.mkdir(parents=True, exist_ok=True)
+                source = plugin_root / "input.tif"
+                tf.imwrite(source, np.zeros((2, 3, 4), dtype=np.uint8))
+
+                self._seed_job("job-1")
+                pool = _RecordingPool()
+
+                with patch("backend.app.pipeline.pipeline.Pool", return_value=pool), patch(
+                    "backend.app.pipeline.pipeline.copy_to_volume",
+                    new=AsyncMock(return_value=(True, "")),
+                ), patch(
+                    "backend.app.pipeline.pipeline.copy_to_host",
+                    new=AsyncMock(return_value=(True, "")),
+                ), patch(
+                    "backend.app.pipeline.pipeline.get_predictor",
+                    return_value=_StubCandleSam3Adapter(),
+                ), patch(
+                    "backend.app.pipeline.pipeline.load_annotation_points",
+                    return_value=np.array([[1.0, 1.0, 0.0]], dtype=np.float32),
+                ), patch(
+                    "backend.app.pipeline.pipeline.run_candle_sam3_image_predictor",
+                    new=AsyncMock(),
+                ) as mock_candle, patch(
+                    "backend.app.pipeline.pipeline.run_image_predictor",
+                    new=AsyncMock(),
+                ) as mock_image, patch(
+                    "backend.app.pipeline.pipeline.run_video_predictor",
+                    new=AsyncMock(),
+                ) as mock_video, patch(
+                    "backend.app.pipeline.pipeline.asyncio.sleep",
+                    new=AsyncMock(),
+                ), patch("backend.app.pipeline.pipeline.shutil.rmtree"), patch(
+                    "backend.app.pipeline.pipeline.time.time",
+                    return_value=789.0,
+                ):
+                    asyncio.run(
+                        app_pipeline.run_pipeline(
+                            "job-1",
+                            "/host/input.tif",
+                            "/host/output.tif",
+                            "candle_sam3",
+                            "ImagePredictor",
+                        )
+                    )
+
+                self.assertEqual(app_config.jobs["job-1"]["status"], "completed")
+                mock_candle.assert_awaited_once()
+                mock_image.assert_not_awaited()
+                mock_video.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/backend/tests/pipeline/test_pipeline.py
+++ b/backend/tests/pipeline/test_pipeline.py
@@ -586,6 +586,7 @@ class _StubCandleSam3Adapter(CandleSam3Adapter):
         super().__init__(binary_path="/fake/sam3")
         self.mask_value = mask_value
         self.captured_jobs = None
+        self.captured_video_call = None
 
     def _run_binary(self, cmd):
         return None
@@ -595,6 +596,16 @@ class _StubCandleSam3Adapter(CandleSam3Adapter):
         return [
             np.full((4, 6), self.mask_value, dtype=np.uint8) for _ in self.captured_jobs
         ]
+
+    def predict_video(self, video_path, seed_point, output_dir, num_frames, *, prompt=None):
+        self.captured_video_call = {
+            "video_path": video_path,
+            "seed_point": seed_point,
+            "output_dir": output_dir,
+            "num_frames": num_frames,
+            "prompt": prompt,
+        }
+        return [np.full((4, 6), self.mask_value, dtype=np.uint8) for _ in range(num_frames)]
 
 
 class CandleSam3PipelineTests(unittest.TestCase):
@@ -727,6 +738,147 @@ class CandleSam3PipelineTests(unittest.TestCase):
 
                 self.assertEqual(app_config.jobs["job-1"]["status"], "completed")
                 mock_candle.assert_awaited_once()
+                mock_image.assert_not_awaited()
+                mock_video.assert_not_awaited()
+
+
+class CandleSam3VideoPipelineTests(unittest.TestCase):
+    def setUp(self):
+        self.jobs_original = copy.deepcopy(app_config.jobs)
+
+    def tearDown(self):
+        app_config.jobs = self.jobs_original
+
+    def _seed_job(self, job_id="job-1"):
+        app_config.jobs[job_id] = {
+            "status": "running",
+            "steps": [
+                {"name": "Transferring", "progress": 0},
+                {"name": "Inference", "progress": 0},
+                {"name": "Saving", "progress": 0},
+            ],
+            "updated_at": 0,
+        }
+
+    def test_run_candle_sam3_video_predictor_writes_result_stack(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            volume_folder = Path(tmpdir) / "frames"
+            volume_folder.mkdir()
+
+            self._seed_job("job-1")
+            adapter = _StubCandleSam3Adapter(mask_value=128)
+            result_stack = np.zeros((3, 4, 6), dtype=np.uint8)
+            annotation_points = np.array(
+                [[3.0, 2.0, 0.0], [3.0, 2.0, 1.0], [3.0, 2.0, 2.0]], dtype=np.float32
+            )
+
+            asyncio.run(
+                app_pipeline.run_candle_sam3_video_predictor(
+                    adapter=adapter,
+                    volume_folder=volume_folder,
+                    annotation_points=annotation_points,
+                    input_shape=(3, 4, 6),
+                    result_stack=result_stack,
+                    job_id="job-1",
+                )
+            )
+
+            self.assertIsNotNone(adapter.captured_video_call)
+            call = adapter.captured_video_call
+            self.assertEqual(call["num_frames"], 3)
+            self.assertEqual(call["video_path"], volume_folder)
+            # Seed point is from frame 0: x=3/6=0.5, y=2/4=0.5
+            self.assertAlmostEqual(call["seed_point"].x, 0.5, places=4)
+            self.assertAlmostEqual(call["seed_point"].y, 0.5, places=4)
+            self.assertEqual(call["seed_point"].label, 1)
+            # All frames written to result_stack
+            np.testing.assert_array_equal(
+                result_stack[0], np.full((4, 6), 128, dtype=np.uint8)
+            )
+            self.assertEqual(app_config.jobs["job-1"]["steps"][1]["progress"], 100)
+
+    def test_run_candle_sam3_video_predictor_resizes_if_wrong_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            volume_folder = Path(tmpdir) / "frames"
+            volume_folder.mkdir()
+
+            self._seed_job("job-1")
+            # Adapter returns 4x6 masks but input_shape says 8x12
+            adapter = _StubCandleSam3Adapter(mask_value=255)
+            result_stack = np.zeros((1, 8, 12), dtype=np.uint8)
+            annotation_points = np.array([[6.0, 4.0, 0.0]], dtype=np.float32)
+
+            asyncio.run(
+                app_pipeline.run_candle_sam3_video_predictor(
+                    adapter=adapter,
+                    volume_folder=volume_folder,
+                    annotation_points=annotation_points,
+                    input_shape=(1, 8, 12),
+                    result_stack=result_stack,
+                    job_id="job-1",
+                )
+            )
+
+            self.assertEqual(result_stack[0].shape, (8, 12))
+            np.testing.assert_array_equal(
+                result_stack[0], np.full((8, 12), 255, dtype=np.uint8)
+            )
+
+    def test_run_pipeline_candle_sam3_video_dispatches_to_video_runner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("backend.app.pipeline.pipeline.config.INTERNAL_VOLUME_PATH", tmpdir):
+                plugin_root = Path(tmpdir, app_config.PLUGIN_NAME)
+                plugin_root.mkdir(parents=True, exist_ok=True)
+                source = plugin_root / "input.tif"
+                tf.imwrite(source, np.zeros((2, 3, 4), dtype=np.uint8))
+
+                self._seed_job("job-1")
+                pool = _RecordingPool()
+
+                with patch("backend.app.pipeline.pipeline.Pool", return_value=pool), patch(
+                    "backend.app.pipeline.pipeline.copy_to_volume",
+                    new=AsyncMock(return_value=(True, "")),
+                ), patch(
+                    "backend.app.pipeline.pipeline.copy_to_host",
+                    new=AsyncMock(return_value=(True, "")),
+                ), patch(
+                    "backend.app.pipeline.pipeline.get_predictor",
+                    return_value=_StubCandleSam3Adapter(),
+                ), patch(
+                    "backend.app.pipeline.pipeline.load_annotation_points",
+                    return_value=np.array([[1.0, 1.0, 0.0]], dtype=np.float32),
+                ), patch(
+                    "backend.app.pipeline.pipeline.run_candle_sam3_video_predictor",
+                    new=AsyncMock(),
+                ) as mock_candle_video, patch(
+                    "backend.app.pipeline.pipeline.run_candle_sam3_image_predictor",
+                    new=AsyncMock(),
+                ) as mock_candle_image, patch(
+                    "backend.app.pipeline.pipeline.run_image_predictor",
+                    new=AsyncMock(),
+                ) as mock_image, patch(
+                    "backend.app.pipeline.pipeline.run_video_predictor",
+                    new=AsyncMock(),
+                ) as mock_video, patch(
+                    "backend.app.pipeline.pipeline.asyncio.sleep",
+                    new=AsyncMock(),
+                ), patch("backend.app.pipeline.pipeline.shutil.rmtree"), patch(
+                    "backend.app.pipeline.pipeline.time.time",
+                    return_value=789.0,
+                ):
+                    asyncio.run(
+                        app_pipeline.run_pipeline(
+                            "job-1",
+                            "/host/input.tif",
+                            "/host/output.tif",
+                            "candle_sam3",
+                            "VideoPredictor",
+                        )
+                    )
+
+                self.assertEqual(app_config.jobs["job-1"]["status"], "completed")
+                mock_candle_video.assert_awaited_once()
+                mock_candle_image.assert_not_awaited()
                 mock_image.assert_not_awaited()
                 mock_video.assert_not_awaited()
 

--- a/backend/tests/util/test_candle_sam3.py
+++ b/backend/tests/util/test_candle_sam3.py
@@ -1,0 +1,274 @@
+"""Unit tests for :mod:`backend.app.util.candle_sam3`."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from PIL import Image
+
+from backend.app.util import candle_sam3 as adapter_mod
+from backend.app.util.candle_sam3 import (
+    CandleSam3Adapter,
+    CandleSam3AdapterError,
+    CandleSam3Box,
+    CandleSam3Job,
+    CandleSam3Point,
+    DEFAULT_SAM3_BINARY,
+    SAM3_BINARY_ENV,
+)
+
+
+def _make_mask_png(path: Path, *, height: int = 4, width: int = 6, fill: int = 255) -> None:
+    arr = np.full((height, width), fill, dtype=np.uint8)
+    Image.fromarray(arr, mode="L").save(path)
+
+
+class IsAvailableTests(unittest.TestCase):
+    def test_returns_false_for_missing_binary(self):
+        adapter = CandleSam3Adapter(binary_path="/nonexistent/path/to/sam3")
+        self.assertFalse(adapter.is_available())
+
+    def test_returns_false_when_path_is_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = CandleSam3Adapter(binary_path=tmp)
+            self.assertFalse(adapter.is_available())
+
+    def test_returns_true_when_path_is_executable_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "sam3"
+            bin_path.write_text("#!/bin/sh\nexit 0\n")
+            bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            adapter = CandleSam3Adapter(binary_path=str(bin_path))
+            self.assertTrue(adapter.is_available())
+
+    def test_resolves_binary_from_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_path = Path(tmp) / "sam3"
+            bin_path.write_text("")
+            bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR)
+            original = os.environ.get(SAM3_BINARY_ENV)
+            try:
+                os.environ[SAM3_BINARY_ENV] = str(bin_path)
+                adapter = CandleSam3Adapter()
+                self.assertEqual(adapter.binary_path, bin_path)
+            finally:
+                if original is None:
+                    os.environ.pop(SAM3_BINARY_ENV, None)
+                else:
+                    os.environ[SAM3_BINARY_ENV] = original
+
+    def test_falls_back_to_default_binary_path(self):
+        original = os.environ.pop(SAM3_BINARY_ENV, None)
+        try:
+            adapter = CandleSam3Adapter()
+            self.assertEqual(adapter.binary_path, Path(DEFAULT_SAM3_BINARY))
+        finally:
+            if original is not None:
+                os.environ[SAM3_BINARY_ENV] = original
+
+
+class NormalizeXyTests(unittest.TestCase):
+    def test_basic_division(self):
+        self.assertEqual(
+            CandleSam3Adapter.normalize_xy(50, 25, width=100, height=100),
+            (0.5, 0.25),
+        )
+
+    def test_clamps_below_zero(self):
+        x, y = CandleSam3Adapter.normalize_xy(-10, -5, width=100, height=100)
+        self.assertEqual((x, y), (0.0, 0.0))
+
+    def test_clamps_above_one(self):
+        x, y = CandleSam3Adapter.normalize_xy(200, 300, width=100, height=100)
+        self.assertEqual((x, y), (1.0, 1.0))
+
+    def test_rejects_non_positive_dimensions(self):
+        with self.assertRaises(ValueError):
+            CandleSam3Adapter.normalize_xy(1, 1, width=0, height=10)
+        with self.assertRaises(ValueError):
+            CandleSam3Adapter.normalize_xy(1, 1, width=10, height=-1)
+
+
+class BuildBatchManifestTests(unittest.TestCase):
+    def test_minimal_prompt_only_job(self):
+        job = CandleSam3Job(name="alpha", image=Path("/tmp/a.png"), prompt="cat")
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertEqual(
+            manifest,
+            {
+                "jobs": [
+                    {
+                        "name": "alpha",
+                        "image": "/tmp/a.png",
+                        "prompt": "cat",
+                        "points": [],
+                        "boxes": [],
+                    }
+                ]
+            },
+        )
+
+    def test_omits_prompt_when_none(self):
+        job = CandleSam3Job(name="bare", image=Path("/tmp/b.png"))
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertNotIn("prompt", manifest["jobs"][0])
+
+    def test_geometry_serialization_order_and_defaults(self):
+        job = CandleSam3Job(
+            name="geo",
+            image=Path("/tmp/c.png"),
+            points=[CandleSam3Point(x=0.1, y=0.2), CandleSam3Point(x=0.3, y=0.4, label=0)],
+            boxes=[CandleSam3Box(cx=0.5, cy=0.5, w=0.2, h=0.2)],
+        )
+        manifest = CandleSam3Adapter.build_batch_manifest([job])
+        self.assertEqual(
+            manifest["jobs"][0]["points"],
+            [
+                {"x": 0.1, "y": 0.2, "label": 1},
+                {"x": 0.3, "y": 0.4, "label": 0},
+            ],
+        )
+        self.assertEqual(
+            manifest["jobs"][0]["boxes"],
+            [{"cx": 0.5, "cy": 0.5, "w": 0.2, "h": 0.2, "label": 1}],
+        )
+
+
+class LoadMaskPngTests(unittest.TestCase):
+    def test_binarizes_grayscale_at_127(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mask.png"
+            arr = np.array([[0, 64, 127], [128, 200, 255]], dtype=np.uint8)
+            Image.fromarray(arr, mode="L").save(path)
+            out = adapter_mod.CandleSam3Adapter.load_mask_png(path)
+            np.testing.assert_array_equal(
+                out,
+                np.array([[0, 0, 0], [255, 255, 255]], dtype=np.uint8),
+            )
+
+    def test_collapses_rgba_to_luminance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mask.png"
+            arr = np.zeros((3, 3, 4), dtype=np.uint8)
+            arr[..., :3] = 255
+            arr[..., 3] = 255
+            Image.fromarray(arr, mode="RGBA").save(path)
+            out = adapter_mod.CandleSam3Adapter.load_mask_png(path)
+            np.testing.assert_array_equal(out, np.full((3, 3), 255, dtype=np.uint8))
+
+
+class PredictImageBatchTests(unittest.TestCase):
+    def test_empty_jobs_returns_empty_list_without_running_binary(self):
+        captured: list = []
+        adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+        adapter._run_binary = lambda cmd: captured.append(cmd)  # type: ignore[assignment]
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(adapter.predict_image_batch([], Path(tmp)), [])
+        self.assertEqual(captured, [])
+
+    def test_runs_binary_with_expected_args_and_returns_masks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "out"
+            jobs = [
+                CandleSam3Job(name="job1", image=Path("/img/1.png"), prompt="x"),
+                CandleSam3Job(name="job2", image=Path("/img/2.png"), prompt="y"),
+            ]
+
+            captured: list[Sequence[str]] = []
+
+            def fake_run(cmd: Sequence[str]):
+                captured.append(list(cmd))
+                for job in jobs:
+                    (output_dir / job.name).mkdir(parents=True, exist_ok=True)
+                    _make_mask_png(output_dir / job.name / "mask.png")
+
+            adapter = CandleSam3Adapter(
+                binary_path="/fake/sam3",
+                checkpoint_path="/fake/sam3.pt",
+                tokenizer_path="/fake/tokenizer.json",
+                cpu=True,
+            )
+            adapter._run_binary = fake_run  # type: ignore[assignment]
+            masks = adapter.predict_image_batch(jobs, output_dir)
+
+            self.assertEqual(len(masks), 2)
+            for mask in masks:
+                self.assertEqual(mask.dtype, np.uint8)
+                self.assertEqual(set(np.unique(mask).tolist()), {255})
+
+            self.assertEqual(len(captured), 1)
+            cmd = captured[0]
+            self.assertEqual(cmd[0], "/fake/sam3")
+            self.assertIn("--checkpoint", cmd)
+            self.assertIn("/fake/sam3.pt", cmd)
+            self.assertIn("--tokenizer", cmd)
+            self.assertIn("/fake/tokenizer.json", cmd)
+            self.assertIn("--cpu", cmd)
+            self.assertIn("--batch-manifest", cmd)
+            self.assertIn("--output-dir", cmd)
+            self.assertEqual(cmd[cmd.index("--output-dir") + 1], str(output_dir))
+
+            manifest_path = output_dir / "manifest.json"
+            self.assertTrue(manifest_path.is_file())
+            self.assertEqual(
+                json.loads(manifest_path.read_text())["jobs"][0]["name"], "job1"
+            )
+
+    def test_missing_mask_raises_adapter_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "out"
+            jobs = [CandleSam3Job(name="solo", image=Path("/img.png"), prompt="z")]
+            output_dir.mkdir(parents=True)
+            (output_dir / "solo").mkdir()
+            adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+            adapter._run_binary = lambda cmd: None  # type: ignore[assignment]
+            with self.assertRaises(CandleSam3AdapterError):
+                adapter.predict_image_batch(jobs, output_dir)
+
+    def test_omits_optional_flags_when_unset(self):
+        captured: list[Sequence[str]] = []
+
+        def fake_run(cmd: Sequence[str]):
+            captured.append(list(cmd))
+            (output_dir / "only").mkdir(parents=True, exist_ok=True)
+            _make_mask_png(output_dir / "only" / "mask.png")
+
+        adapter = CandleSam3Adapter(binary_path="/fake/sam3")
+        adapter._run_binary = fake_run  # type: ignore[assignment]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            adapter.predict_image_batch(
+                [CandleSam3Job(name="only", image=Path("/x.png"), prompt="z")],
+                output_dir,
+            )
+
+        cmd = captured[0]
+        self.assertNotIn("--checkpoint", cmd)
+        self.assertNotIn("--tokenizer", cmd)
+        self.assertNotIn("--cpu", cmd)
+
+
+class RunBinaryTests(unittest.TestCase):
+    def test_called_process_error_raises_adapter_error(self):
+        adapter = CandleSam3Adapter(binary_path="/bin/false")
+        with self.assertRaises(CandleSam3AdapterError) as cm:
+            adapter._run_binary(["/bin/false"])
+        self.assertIn("candle-sam3 binary failed", str(cm.exception))
+
+    def test_successful_invocation_returns_completed_process(self):
+        adapter = CandleSam3Adapter(binary_path="/bin/true")
+        result = adapter._run_binary(["/bin/echo", "hello"])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("hello", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/util/test_candle_sam3.py
+++ b/backend/tests/util/test_candle_sam3.py
@@ -256,6 +256,154 @@ class PredictImageBatchTests(unittest.TestCase):
         self.assertNotIn("--cpu", cmd)
 
 
+class PredictVideoTests(unittest.TestCase):
+    """Tests for CandleSam3Adapter.predict_video."""
+
+    def _make_adapter(self) -> CandleSam3Adapter:
+        return CandleSam3Adapter(binary_path="/fake/sam3")
+
+    def _write_video_masks(self, output_dir: Path, num_frames: int, *, fill: int = 255) -> None:
+        masks_dir = output_dir / "masks"
+        masks_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(num_frames):
+            _make_mask_png(
+                masks_dir / f"frame_{i:06d}_obj_000001.png",
+                height=4,
+                width=6,
+                fill=fill,
+            )
+
+    def test_predict_video_returns_masks_in_order(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.5, y=0.5, label=1)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "out"
+
+            def _fake_run(cmd):
+                self._write_video_masks(output_dir, num_frames=3)
+                return None
+
+            adapter._run_binary = _fake_run
+            masks = adapter.predict_video(video_dir, seed, output_dir, num_frames=3)
+
+        self.assertEqual(len(masks), 3)
+        for mask in masks:
+            self.assertEqual(mask.shape, (4, 6))
+            np.testing.assert_array_equal(mask, np.full((4, 6), 255, dtype=np.uint8))
+
+    def test_predict_video_passes_correct_cli_args(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.25, y=0.75, label=1)
+        captured: list[list[str]] = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "out"
+
+            def _fake_run(cmd):
+                captured.append(list(cmd))
+                self._write_video_masks(output_dir, num_frames=1)
+                return None
+
+            adapter._run_binary = _fake_run
+            adapter.predict_video(video_dir, seed, output_dir, num_frames=1)
+
+        self.assertEqual(len(captured), 1)
+        cmd = captured[0]
+        self.assertIn("--video", cmd)
+        video_idx = cmd.index("--video")
+        self.assertEqual(cmd[video_idx + 1], str(video_dir))
+        self.assertIn("--point", cmd)
+        point_idx = cmd.index("--point")
+        self.assertEqual(cmd[point_idx + 1], "0.25,0.75")
+        self.assertIn("--point-label", cmd)
+        label_idx = cmd.index("--point-label")
+        self.assertEqual(cmd[label_idx + 1], "1")
+
+    def test_predict_video_includes_video_prompt_when_given(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.5, y=0.5)
+        captured: list[list[str]] = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "out"
+
+            def _fake_run(cmd):
+                captured.append(list(cmd))
+                self._write_video_masks(output_dir, num_frames=1)
+                return None
+
+            adapter._run_binary = _fake_run
+            adapter.predict_video(video_dir, seed, output_dir, num_frames=1, prompt="a cell")
+
+        cmd = captured[0]
+        self.assertIn("--video-prompt", cmd)
+        prompt_idx = cmd.index("--video-prompt")
+        self.assertEqual(cmd[prompt_idx + 1], "a cell")
+
+    def test_predict_video_omits_video_prompt_when_none(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.5, y=0.5)
+        captured: list[list[str]] = []
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "out"
+
+            def _fake_run(cmd):
+                captured.append(list(cmd))
+                self._write_video_masks(output_dir, num_frames=1)
+                return None
+
+            adapter._run_binary = _fake_run
+            adapter.predict_video(video_dir, seed, output_dir, num_frames=1)
+
+        self.assertNotIn("--video-prompt", captured[0])
+
+    def test_predict_video_missing_mask_raises_adapter_error(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.5, y=0.5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "out"
+
+            def _fake_run(cmd):
+                return None
+
+            adapter._run_binary = _fake_run
+            with self.assertRaises(CandleSam3AdapterError) as ctx:
+                adapter.predict_video(video_dir, seed, output_dir, num_frames=2)
+
+        self.assertIn("frame 0", str(ctx.exception))
+
+    def test_predict_video_creates_output_dir_if_missing(self):
+        adapter = self._make_adapter()
+        seed = CandleSam3Point(x=0.5, y=0.5)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_dir = Path(tmpdir) / "frames"
+            video_dir.mkdir()
+            output_dir = Path(tmpdir) / "nested" / "output"
+
+            def _fake_run(cmd):
+                self._write_video_masks(output_dir, num_frames=1)
+                return None
+
+            adapter._run_binary = _fake_run
+            adapter.predict_video(video_dir, seed, output_dir, num_frames=1)
+
+            self.assertTrue(output_dir.is_dir())
+
+
 class RunBinaryTests(unittest.TestCase):
     def test_called_process_error_raises_adapter_error(self):
         adapter = CandleSam3Adapter(binary_path="/bin/false")

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -201,6 +201,75 @@ class NetworkTests(unittest.TestCase):
             predictor = app_network.get_predictor("sam3", "ImagePredictor")
         self.assertEqual(predictor, ("sam3", "sam3-image-model"))
 
+    def test_get_predictor_candle_sam3_requires_image_predictor(self):
+        app_config.loaded_model_name = None
+        app_config.loaded_predictor = None
+        with self.assertRaises(ValueError) as ctx:
+            app_network.get_predictor("candle_sam3", "VideoPredictor")
+        self.assertIn("ImagePredictor", str(ctx.exception))
+
+    def test_get_predictor_candle_sam3_missing_checkpoint_raises(self):
+        app_config.loaded_model_name = None
+        app_config.loaded_predictor = None
+        with patch("backend.app.util.network.os.path.isfile", return_value=False):
+            with self.assertRaises(FileNotFoundError):
+                app_network.get_predictor("candle_sam3", "ImagePredictor")
+
+    def test_get_predictor_candle_sam3_missing_binary_raises(self):
+        app_config.loaded_model_name = None
+        app_config.loaded_predictor = None
+
+        class _UnavailableAdapter:
+            def __init__(self, *_, **__):
+                self.binary_path = "/missing/sam3"
+
+            def is_available(self):
+                return False
+
+        with patch("backend.app.util.network.os.path.isfile", return_value=True), patch(
+            "backend.app.util.network.CandleSam3Adapter",
+            _UnavailableAdapter,
+        ):
+            with self.assertRaises(FileNotFoundError) as ctx:
+                app_network.get_predictor("candle_sam3", "ImagePredictor")
+        self.assertIn("candle-sam3 binary", str(ctx.exception))
+
+    def test_get_predictor_candle_sam3_success_returns_adapter(self):
+        app_config.loaded_model_name = None
+        app_config.loaded_predictor = None
+
+        sentinel = object()
+
+        class _AvailableAdapter:
+            def __init__(self, *_, **__):
+                self.created = True
+
+            def is_available(self):
+                return True
+
+        # Patch the class to return our sentinel via init
+        def fake_ctor(*args, **kwargs):
+            return _AvailableAdapter(*args, **kwargs)
+
+        with patch("backend.app.util.network.os.path.isfile", return_value=True), patch(
+            "backend.app.util.network.CandleSam3Adapter",
+            side_effect=fake_ctor,
+        ) as mocked_adapter:
+            predictor = app_network.get_predictor("candle_sam3", "ImagePredictor")
+        self.assertTrue(getattr(predictor, "created", False))
+        mocked_adapter.assert_called_once()
+
+    def test_models_available_includes_candle_sam3(self):
+        with patch("backend.app.util.network.build_sam2", None), patch(
+            "backend.app.util.network.SAM2ImagePredictor", None
+        ), patch("backend.app.util.network.build_sam3_video_predictor", None), patch(
+            "backend.app.util.network.Sam3Processor", None
+        ), patch(
+            "backend.app.util.network._candle_sam3_available",
+            return_value=True,
+        ):
+            self.assertTrue(app_network.models_available())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -201,12 +201,12 @@ class NetworkTests(unittest.TestCase):
             predictor = app_network.get_predictor("sam3", "ImagePredictor")
         self.assertEqual(predictor, ("sam3", "sam3-image-model"))
 
-    def test_get_predictor_candle_sam3_requires_image_predictor(self):
+    def test_get_predictor_candle_sam3_unknown_predictor_type_raises(self):
         app_config.loaded_model_name = None
         app_config.loaded_predictor = None
         with self.assertRaises(ValueError) as ctx:
-            app_network.get_predictor("candle_sam3", "VideoPredictor")
-        self.assertIn("ImagePredictor", str(ctx.exception))
+            app_network.get_predictor("candle_sam3", "BadPredictor")
+        self.assertIn("BadPredictor", str(ctx.exception))
 
     def test_get_predictor_candle_sam3_missing_checkpoint_raises(self):
         app_config.loaded_model_name = None
@@ -238,8 +238,6 @@ class NetworkTests(unittest.TestCase):
         app_config.loaded_model_name = None
         app_config.loaded_predictor = None
 
-        sentinel = object()
-
         class _AvailableAdapter:
             def __init__(self, *_, **__):
                 self.created = True
@@ -247,7 +245,6 @@ class NetworkTests(unittest.TestCase):
             def is_available(self):
                 return True
 
-        # Patch the class to return our sentinel via init
         def fake_ctor(*args, **kwargs):
             return _AvailableAdapter(*args, **kwargs)
 
@@ -256,6 +253,28 @@ class NetworkTests(unittest.TestCase):
             side_effect=fake_ctor,
         ) as mocked_adapter:
             predictor = app_network.get_predictor("candle_sam3", "ImagePredictor")
+        self.assertTrue(getattr(predictor, "created", False))
+        mocked_adapter.assert_called_once()
+
+    def test_get_predictor_candle_sam3_video_predictor_success(self):
+        app_config.loaded_model_name = None
+        app_config.loaded_predictor = None
+
+        class _AvailableAdapter:
+            def __init__(self, *_, **__):
+                self.created = True
+
+            def is_available(self):
+                return True
+
+        def fake_ctor(*args, **kwargs):
+            return _AvailableAdapter(*args, **kwargs)
+
+        with patch("backend.app.util.network.os.path.isfile", return_value=True), patch(
+            "backend.app.util.network.CandleSam3Adapter",
+            side_effect=fake_ctor,
+        ) as mocked_adapter:
+            predictor = app_network.get_predictor("candle_sam3", "VideoPredictor")
         self.assertTrue(getattr(predictor, "created", False))
         mocked_adapter.assert_called_once()
 


### PR DESCRIPTION
## Summary

**Merge after:** #6, #7 (adapter + image pipeline)

- `candle_sam3.py`: adds `predict_video` method — calls the binary with `--video <frame_dir> --point x,y --point-label 1` and reads per-frame masks from `masks/frame_XXXXXX_obj_000001.png`. Seeding is single-frame (frame 0 only), matching the upstream candle-sam3 video CLI limitation.
- `pipeline.py`: adds `run_candle_sam3_video_predictor` — seeds on frame 0 from the first annotation point, calls `adapter.predict_video`, resizes masks, writes to `result_stack`.
- Dispatch updated: `model_type=candle_sam3` + `predictor_type=VideoPredictor` routes to the new runner.
- `network.py`: `candle_sam3` now accepts both ImagePredictor and VideoPredictor (same adapter returned; pipeline decides which method to call).

## Test plan

- [ ] `test_candle_sam3.py` — 6 new `PredictVideoTests` (masks in order, correct CLI args, prompt flag, no-prompt, missing mask error, output dir creation)
- [ ] `test_pipeline.py` — 3 new `CandleSam3VideoPipelineTests` (writes stack, resize, dispatch routing)
- [ ] `test_network.py` — 1 new test for VideoPredictor success path
- [ ] 94 total tests pass (1 pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)