### PR TITLE
Add candle-sam3 image segmentation (pure Rust)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,9 +7,12 @@ publish = false
 
 [dependencies]
 async-trait = "=0.1.77"
+candle-core = { path = "../../candle_sam3_main/candle-core", package = "candle-core", version = "0.9.2" }
+candle-nn = { path = "../../candle_sam3_main/candle-nn", version = "0.9.2" }
+candle-transformers = { path = "../../candle_sam3_main/candle-transformers", version = "0.9.2" }
 axum = { version = "=0.6.20", features = ["json", "macros"] }
 futures-util = "=0.3.31"
-image = { version = "=0.25.10", default-features = false, features = ["jpeg"] }
+image = { version = "=0.25.10", default-features = false, features = ["jpeg", "tiff"] }
 indexmap = "=2.2.6"
 reqwest = { version = "=0.11.27", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "=1.0.195", features = ["derive"] }

--- a/backend/src/app_state.rs
+++ b/backend/src/app_state.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use candle_core::Device;
+use candle_transformers::models::sam3;
 use tokio::sync::{Mutex, RwLock, Semaphore};
 
 use crate::{
@@ -9,6 +11,12 @@ use crate::{
     inference::registry::ModelRegistry,
 };
 
+pub struct Sam3ModelHandle {
+    pub image_model: Arc<sam3::Sam3ImageModel>,
+    pub tracker: Arc<sam3::Sam3TrackerModel>,
+    pub device: Device,
+}
+
 #[derive(Clone)]
 pub struct AppState {
     config: Arc<AppConfig>,
@@ -16,6 +24,7 @@ pub struct AppState {
     jobs: Arc<RwLock<HashMap<String, JobRecord>>>,
     startup_status: Arc<RwLock<StartupStatus>>,
     model_registry: Arc<Mutex<ModelRegistry>>,
+    sam3_handle: Arc<RwLock<Option<Arc<Sam3ModelHandle>>>>,
     inference_limit: Arc<Semaphore>,
 }
 
@@ -31,6 +40,7 @@ impl AppState {
             jobs: Arc::new(RwLock::new(HashMap::new())),
             startup_status: Arc::new(RwLock::new(StartupStatus::pending())),
             model_registry: Arc::new(Mutex::new(ModelRegistry::new())),
+            sam3_handle: Arc::new(RwLock::new(None)),
             inference_limit: Arc::new(Semaphore::new(1)),
         })
     }
@@ -52,7 +62,16 @@ impl AppState {
     }
 
     pub async fn ml_runtime_ready(&self) -> bool {
-        self.model_registry.lock().await.runtime_ready()
+        self.sam3_handle.read().await.is_some()
+    }
+
+    pub async fn sam3_handle(&self) -> Option<Arc<Sam3ModelHandle>> {
+        self.sam3_handle.read().await.clone()
+    }
+
+    pub async fn set_sam3_handle(&self, handle: Sam3ModelHandle) {
+        *self.sam3_handle.write().await = Some(Arc::new(handle));
+        self.model_registry.lock().await.mark_ready();
     }
 
     pub async fn create_job(&self, job_id: String) -> JobRecord {

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -13,6 +13,8 @@ pub enum AppError {
     #[error("{0}")]
     NotImplemented(String),
     #[error("{0}")]
+    Internal(String),
+    #[error("{0}")]
     Upstream(String),
     #[error("{0}")]
     Io(#[from] std::io::Error),
@@ -35,6 +37,10 @@ impl AppError {
         Self::NotImplemented(message.into())
     }
 
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+
     pub fn upstream(message: impl Into<String>) -> Self {
         Self::Upstream(message.into())
     }
@@ -46,8 +52,10 @@ impl IntoResponse for AppError {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+            Self::Internal(_) | Self::Io(_) | Self::Http(_) | Self::Json(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
             Self::Upstream(_) => StatusCode::BAD_GATEWAY,
-            Self::Io(_) | Self::Http(_) | Self::Json(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         (status, self.to_string()).into_response()

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -1,38 +1,110 @@
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use candle_core::DType;
+use candle_transformers::models::sam3;
 
 use crate::{
+    app_state::Sam3ModelHandle,
     error::AppError,
     imaging::tiff_io::ImageFrame,
     inference::{
+        candle_sam3_helpers::{
+            build_geometry_prompt, frame_to_chw_tensor, normalize_for_sam3,
+            threshold_mask_logits_to_frame,
+        },
         image::{FrameMask, ImageSegmenter, PositivePointPrompt},
         video::{VideoFramePrompt, VideoSegmenter},
     },
 };
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CandleSam3ImageSegmenter {
-    pub checkpoint_path: PathBuf,
+    pub handle: Arc<Sam3ModelHandle>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CandleSam3VideoSegmenter {
-    pub checkpoint_path: PathBuf,
+    pub handle: Arc<Sam3ModelHandle>,
+}
+
+/// Load SAM3 image and tracker models from a `.pt` checkpoint.
+pub fn load_sam3_handle(
+    checkpoint_path: &std::path::Path,
+    device: candle_core::Device,
+) -> Result<Sam3ModelHandle, AppError> {
+    let config = sam3::Config::default();
+    let source = sam3::Sam3CheckpointSource::upstream_pth(checkpoint_path);
+    let image_model =
+        sam3::Sam3ImageModel::from_checkpoint_source(&config, &source, DType::F32, &device)
+            .map_err(|e| AppError::internal(e.to_string()))?;
+    let tracker = sam3::Sam3TrackerModel::from_checkpoint_source(&config, &source, DType::F32, &device)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    Ok(Sam3ModelHandle {
+        image_model: Arc::new(image_model),
+        tracker: Arc::new(tracker),
+        device,
+    })
 }
 
 #[async_trait]
 impl ImageSegmenter for CandleSam3ImageSegmenter {
     async fn segment(
         &self,
-        _frame: &ImageFrame,
-        _prompts: &[PositivePointPrompt],
+        frame: &ImageFrame,
+        prompts: &[PositivePointPrompt],
     ) -> Result<FrameMask, AppError> {
-        Err(AppError::not_implemented(format!(
-            "Candle SAM3 image inference is not implemented yet for {}",
-            self.checkpoint_path.display()
-        )))
+        let handle = self.handle.clone();
+        let frame = frame.clone();
+        let prompts = prompts.to_vec();
+        tokio::task::spawn_blocking(move || run_image_inference(&handle, &frame, &prompts))
+            .await
+            .map_err(|e| AppError::internal(e.to_string()))?
     }
+}
+
+fn run_image_inference(
+    handle: &Sam3ModelHandle,
+    frame: &ImageFrame,
+    prompts: &[PositivePointPrompt],
+) -> Result<FrameMask, AppError> {
+    let model = &*handle.image_model;
+    let device = &handle.device;
+    let config = model.config();
+
+    let chw = frame_to_chw_tensor(frame, device)?;
+    let preprocessed = normalize_for_sam3(
+        &chw.unsqueeze(0).map_err(|e| AppError::internal(e.to_string()))?,
+        config.image.image_size,
+        &config.image.image_mean,
+        &config.image.image_std,
+        device,
+    )?;
+
+    let visual = model
+        .encode_image_features(&preprocessed)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+
+    let geometry = build_geometry_prompt(prompts, frame.width, frame.height, device)?;
+    let geo_encoded = model
+        .encode_geometry_prompt(&geometry, &visual)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let fused = model
+        .encode_fused_prompt(&visual, &geo_encoded)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let decoder = model
+        .decode_grounding(&fused, &geo_encoded)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let segmentation = model
+        .segment_grounding(&visual, &decoder, &fused, &geo_encoded)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+
+    threshold_mask_logits_to_frame(
+        &segmentation.mask_logits,
+        frame.width,
+        frame.height,
+        config.image.image_size,
+    )
 }
 
 #[async_trait]
@@ -42,9 +114,8 @@ impl VideoSegmenter for CandleSam3VideoSegmenter {
         _frame_count: usize,
         _prompts: &[VideoFramePrompt],
     ) -> Result<Vec<FrameMask>, AppError> {
-        Err(AppError::not_implemented(format!(
-            "Candle SAM3 video inference is not implemented yet for {}",
-            self.checkpoint_path.display()
-        )))
+        Err(AppError::not_implemented(
+            "Candle SAM3 video inference not yet wired — use branch rust/candle-sam3-video-inference",
+        ))
     }
 }

--- a/backend/src/inference/candle_sam3_helpers.rs
+++ b/backend/src/inference/candle_sam3_helpers.rs
@@ -1,0 +1,127 @@
+use candle_core::{Device, Tensor};
+use candle_nn::ops;
+use candle_transformers::models::sam3;
+
+use crate::{
+    error::AppError,
+    imaging::tiff_io::ImageFrame,
+    inference::image::{FrameMask, PositivePointPrompt},
+};
+
+/// Convert an `ImageFrame` (u8 pixels, HWC layout) to a float CHW tensor in [0, 1].
+/// Single-channel frames are replicated to three channels for SAM3's RGB encoder.
+pub fn frame_to_chw_tensor(frame: &ImageFrame, device: &Device) -> Result<Tensor, AppError> {
+    let hw = frame.height * frame.width;
+    let channels = frame.channels;
+    let mut chw: Vec<f32> = vec![0.0; channels * hw];
+    for (idx, &pixel) in frame.pixels.iter().enumerate() {
+        let pixel_idx = idx / channels;
+        let channel_idx = idx % channels;
+        chw[channel_idx * hw + pixel_idx] = pixel as f32 / 255.0;
+    }
+    let chw = if channels == 1 {
+        let mut rgb = vec![0.0f32; 3 * hw];
+        for i in 0..hw {
+            let v = chw[i];
+            rgb[i] = v;
+            rgb[hw + i] = v;
+            rgb[2 * hw + i] = v;
+        }
+        rgb
+    } else {
+        chw
+    };
+    Tensor::from_vec(chw, (3, frame.height, frame.width), device)
+        .map_err(|e| AppError::internal(e.to_string()))
+}
+
+/// Resize a BCHW float tensor to `target_size`×`target_size` and apply per-channel
+/// mean/std normalization as expected by the SAM3 encoder.
+pub fn normalize_for_sam3(
+    image_bchw: &Tensor,
+    target_size: usize,
+    mean: &[f32; 3],
+    std: &[f32; 3],
+    device: &Device,
+) -> Result<Tensor, AppError> {
+    let resized = image_bchw
+        .upsample_bilinear2d(target_size, target_size, false)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let mean_t = Tensor::from_vec(mean.to_vec(), (1, 3, 1, 1), device)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let std_t = Tensor::from_vec(std.to_vec(), (1, 3, 1, 1), device)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    resized
+        .broadcast_sub(&mean_t)
+        .and_then(|t| t.broadcast_div(&std_t))
+        .map_err(|e| AppError::internal(e.to_string()))
+}
+
+/// Build a SAM3 `GeometryPrompt` from a list of positive click prompts.
+/// Pixel coordinates are normalised to [0, 1] by dividing by frame dimensions.
+pub fn build_geometry_prompt(
+    prompts: &[PositivePointPrompt],
+    frame_width: usize,
+    frame_height: usize,
+    device: &Device,
+) -> Result<sam3::GeometryPrompt, AppError> {
+    if prompts.is_empty() {
+        return Ok(sam3::GeometryPrompt::default());
+    }
+    let w = frame_width as f32;
+    let h = frame_height as f32;
+    let coords: Vec<f32> = prompts
+        .iter()
+        .flat_map(|p| [(p.x / w).clamp(0.0, 1.0), (p.y / h).clamp(0.0, 1.0)])
+        .collect();
+    let labels: Vec<u32> = vec![1; prompts.len()];
+    let n = prompts.len();
+    let points_xy = Tensor::from_vec(coords, (1, n, 2), device)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let point_labels = Tensor::from_vec(labels, (1, n), device)
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    Ok(sam3::GeometryPrompt {
+        points_xy: Some(points_xy),
+        point_labels: Some(point_labels),
+        ..Default::default()
+    })
+}
+
+/// Threshold raw mask logits (shape [batch, query, H, W]) to a binary `FrameMask`.
+///
+/// The best query (index 0) is selected, upsampled via bilinear interpolation to
+/// `model_size`×`model_size`, sigmoid-activated, then resampled to the target output
+/// dimensions. Pixels where probability > 0.5 are set to 255, others to 0.
+pub fn threshold_mask_logits_to_frame(
+    mask_logits: &Tensor,
+    out_width: usize,
+    out_height: usize,
+    model_size: usize,
+) -> Result<FrameMask, AppError> {
+    let logits_2d = mask_logits
+        .i((0, 0))
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let probs = logits_2d
+        .unsqueeze(0)
+        .and_then(|t| t.unsqueeze(0))
+        .and_then(|t| t.upsample_bilinear2d(model_size, model_size, false))
+        .and_then(|t| ops::sigmoid(&t))
+        .and_then(|t| t.upsample_bilinear2d(out_height, out_width, false))
+        .and_then(|t| t.i((0, 0)))
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let rows = probs
+        .to_vec2::<f32>()
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    let pixels: Vec<u8> = rows
+        .iter()
+        .flat_map(|row| row.iter().map(|&v| if v > 0.5 { 255 } else { 0 }))
+        .collect();
+    Ok(FrameMask {
+        width: out_width,
+        height: out_height,
+        pixels,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/src/inference/candle_sam3_helpers/tests.rs
+++ b/backend/src/inference/candle_sam3_helpers/tests.rs
@@ -1,0 +1,131 @@
+use candle_core::{Device, Tensor};
+
+use crate::{imaging::tiff_io::ImageFrame, inference::image::PositivePointPrompt};
+
+use super::{
+    build_geometry_prompt, frame_to_chw_tensor, normalize_for_sam3,
+    threshold_mask_logits_to_frame,
+};
+
+#[test]
+fn frame_to_chw_single_channel_replicates_to_rgb() {
+    let frame = ImageFrame {
+        width: 2,
+        height: 2,
+        channels: 1,
+        pixels: vec![0, 128, 255, 64],
+    };
+    let tensor = frame_to_chw_tensor(&frame, &Device::Cpu).unwrap();
+    assert_eq!(tensor.dims(), &[3, 2, 2]);
+    let vals = tensor.to_vec3::<f32>().unwrap();
+    assert_eq!(vals[0], vals[1], "R and G channels should be identical");
+    assert_eq!(vals[0], vals[2], "R and B channels should be identical");
+    let flat: Vec<f32> = vals[0].iter().flatten().copied().collect();
+    assert!(flat[0].abs() < 1e-5, "pixel 0 should map to 0.0");
+    assert!((flat[2] - 1.0).abs() < 1e-5, "pixel 255 should map to 1.0");
+}
+
+#[test]
+fn frame_to_chw_three_channel_preserves_order() {
+    let frame = ImageFrame {
+        width: 1,
+        height: 1,
+        channels: 3,
+        pixels: vec![255, 128, 0],
+    };
+    let tensor = frame_to_chw_tensor(&frame, &Device::Cpu).unwrap();
+    assert_eq!(tensor.dims(), &[3, 1, 1]);
+    let vals = tensor.to_vec3::<f32>().unwrap();
+    assert!((vals[0][0][0] - 1.0).abs() < 1e-5);
+    assert!((vals[1][0][0] - 128.0 / 255.0).abs() < 1e-3);
+    assert!(vals[2][0][0].abs() < 1e-5);
+}
+
+#[test]
+fn normalize_for_sam3_resizes_and_returns_correct_shape() {
+    let input = Tensor::zeros((1, 3, 8, 8), candle_core::DType::F32, &Device::Cpu).unwrap();
+    let mean = [0.485, 0.456, 0.406];
+    let std = [0.229, 0.224, 0.225];
+    let result = normalize_for_sam3(&input, 4, &mean, &std, &Device::Cpu).unwrap();
+    assert_eq!(result.dims(), &[1, 3, 4, 4]);
+}
+
+#[test]
+fn normalize_for_sam3_subtracts_mean() {
+    // A tensor filled with mean values should normalise to zero.
+    let mean_val = 0.485f32;
+    let pixels = vec![mean_val; 3 * 4 * 4];
+    let input =
+        Tensor::from_vec(pixels, (1, 3, 4, 4), &Device::Cpu).unwrap();
+    let mean = [0.485, 0.456, 0.406];
+    let std = [1.0, 1.0, 1.0]; // unit std so only mean subtraction is tested
+    let result = normalize_for_sam3(&input, 4, &mean, &std, &Device::Cpu).unwrap();
+    let vals = result.to_vec4::<f32>().unwrap();
+    // Channel 0 should be ~0, channels 1 and 2 non-zero
+    assert!(vals[0][0][0][0].abs() < 1e-4);
+}
+
+#[test]
+fn build_geometry_prompt_normalises_pixel_coords() {
+    let prompts = vec![
+        PositivePointPrompt { x: 100.0, y: 50.0 },
+        PositivePointPrompt { x: 200.0, y: 150.0 },
+    ];
+    let prompt = build_geometry_prompt(&prompts, 400, 200, &Device::Cpu).unwrap();
+    let coords = prompt.points_xy.unwrap().to_vec3::<f32>().unwrap();
+    assert!((coords[0][0][0] - 0.25).abs() < 1e-5); // 100/400
+    assert!((coords[0][0][1] - 0.25).abs() < 1e-5); // 50/200
+    assert!((coords[0][1][0] - 0.5).abs() < 1e-5);  // 200/400
+    assert!((coords[0][1][1] - 0.75).abs() < 1e-5); // 150/200
+    let labels = prompt.point_labels.unwrap().to_vec2::<u32>().unwrap();
+    assert_eq!(labels[0], vec![1, 1]);
+}
+
+#[test]
+fn build_geometry_prompt_clamps_out_of_range_coords() {
+    let prompts = vec![PositivePointPrompt { x: -50.0, y: 9999.0 }];
+    let prompt = build_geometry_prompt(&prompts, 100, 100, &Device::Cpu).unwrap();
+    let coords = prompt.points_xy.unwrap().to_vec3::<f32>().unwrap();
+    assert!(coords[0][0][0].abs() < 1e-5);
+    assert!((coords[0][0][1] - 1.0).abs() < 1e-5);
+}
+
+#[test]
+fn build_geometry_prompt_empty_prompts_returns_default() {
+    let prompt = build_geometry_prompt(&[], 100, 100, &Device::Cpu).unwrap();
+    assert!(prompt.is_empty());
+}
+
+#[test]
+fn threshold_mask_logits_positive_becomes_255() {
+    // Large positive logit → sigmoid ≈ 1 → 255
+    let logits = Tensor::from_vec(vec![100.0f32], (1, 1, 1, 1), &Device::Cpu).unwrap();
+    let mask = threshold_mask_logits_to_frame(&logits, 1, 1, 1).unwrap();
+    assert_eq!(mask.pixels, vec![255]);
+}
+
+#[test]
+fn threshold_mask_logits_negative_becomes_0() {
+    let logits = Tensor::from_vec(vec![-100.0f32], (1, 1, 1, 1), &Device::Cpu).unwrap();
+    let mask = threshold_mask_logits_to_frame(&logits, 1, 1, 1).unwrap();
+    assert_eq!(mask.pixels, vec![0]);
+}
+
+#[test]
+fn threshold_mask_logits_mixed_2x2() {
+    let logits =
+        Tensor::from_vec(vec![100.0f32, -100.0, -100.0, 100.0], (1, 1, 2, 2), &Device::Cpu)
+            .unwrap();
+    let mask = threshold_mask_logits_to_frame(&logits, 2, 2, 2).unwrap();
+    assert_eq!(mask.width, 2);
+    assert_eq!(mask.height, 2);
+    assert_eq!(mask.pixels, vec![255, 0, 0, 255]);
+}
+
+#[test]
+fn threshold_mask_logits_upsample_to_larger_output() {
+    let logits = Tensor::from_vec(vec![50.0f32], (1, 1, 1, 1), &Device::Cpu).unwrap();
+    let mask = threshold_mask_logits_to_frame(&logits, 4, 4, 4).unwrap();
+    assert_eq!(mask.pixels.len(), 16);
+    assert!(mask.pixels.iter().all(|&v| v == 255));
+}

--- a/backend/src/inference/mod.rs
+++ b/backend/src/inference/mod.rs
@@ -1,5 +1,6 @@
 pub mod candle_sam2;
 pub mod candle_sam3;
+pub mod candle_sam3_helpers;
 pub mod image;
 pub mod registry;
 pub mod video;

--- a/backend/src/inference/registry.rs
+++ b/backend/src/inference/registry.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 #[derive(Debug)]
 pub struct ModelRegistry {
     supported_models: HashSet<&'static str>,
+    ready: bool,
 }
 
 impl ModelRegistry {
@@ -15,11 +16,18 @@ impl ModelRegistry {
             "sam3",
         ]);
 
-        Self { supported_models }
+        Self {
+            supported_models,
+            ready: false,
+        }
+    }
+
+    pub fn mark_ready(&mut self) {
+        self.ready = true;
     }
 
     pub fn runtime_ready(&self) -> bool {
-        false
+        self.ready
     }
 
     pub fn supports_model(&self, model_name: &str) -> bool {


### PR DESCRIPTION
## Summary

- Adds `candle-core`, `candle-nn`, and `candle-transformers` path deps pointing at `den-sq/candle_sam3` (commit `770d20ca`)
- Introduces `inference/candle_sam3_helpers.rs`: tensor conversion, SAM3 normalisation, geometry-prompt construction, and mask thresholding utilities, each with unit tests
- Implements `CandleSam3ImageSegmenter` (the `ImageSegmenter` trait) using `Sam3ImageModel`: encode → prompt → decode → threshold pipeline run via `spawn_blocking`
- Extends `AppState` with `Sam3ModelHandle` (Arc-wrapped image model + tracker + device) and a `sam3_handle` RwLock field; adds `load_sam3_handle()` factory

## Test plan

- [ ] `cargo test -p ouroboros-autoseg-plugin-backend` — all helper unit tests pass
- [ ] `cargo build --release` succeeds (requires `candle_sam3_main` at `../../candle_sam3_main/`)
- [ ] Image segmentation smoke test: load a `.pt` checkpoint, run `CandleSam3ImageSegmenter::segment_image()` on a test frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)