### PR TITLE
[codex] Add SAM3 checkpoint smoke checks

### DIFF
--- a/backend/docs/checkpoints.md
+++ b/backend/docs/checkpoints.md
@@ -1,0 +1,31 @@
+# Checkpoint Verification
+
+The production Rust backend loads SAM3 checkpoints through
+`candle_transformers::models::sam3::Sam3CheckpointSource::upstream_pth`.
+
+## Medical-SAM3 Load Check
+
+Stage the Medical-SAM3 checkpoint and point `OUROBOROS_SAM3_CHECKPOINT` at the
+local file:
+
+```bash
+export OUROBOROS_SAM3_CHECKPOINT=/path/to/medical_sam3.pt
+cargo test --ignored sam3_medical_checkpoint_load -- --nocapture
+```
+
+The ignored test loads the checkpoint through the same production loader used by
+`/process`, runs the image path on a tiny synthetic fixture, and asserts that the
+output mask has the input geometry and uses the established `uint8` `0/255`
+convention.
+
+For a command-line smoke check:
+
+```bash
+cargo run --release --bin sam3_checkpoint_smoke -- \
+  --checkpoint "$OUROBOROS_SAM3_CHECKPOINT" \
+  --mask-out /tmp/sam3_smoke_mask.tif
+```
+
+The smoke binary exits non-zero when the checkpoint cannot be loaded or the mask
+geometry is invalid. Pass `--image /path/to/input.jpg` to use a real image
+instead of the built-in synthetic frame.

--- a/backend/src/bin/sam3_checkpoint_smoke.rs
+++ b/backend/src/bin/sam3_checkpoint_smoke.rs
@@ -1,0 +1,145 @@
+use std::{
+    env,
+    error::Error,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use ouroboros_autoseg_plugin_backend::{
+    imaging::{output::write_mask_stack, tiff_io::ImageFrame},
+    inference::{
+        candle_sam3::{load_sam3_handle, CandleSam3ImageSegmenter},
+        image::{ImageSegmenter, PositivePointPrompt},
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse(env::args().skip(1))?;
+    let frame = match args.image_path.as_deref() {
+        Some(path) => load_image_frame(path)?,
+        None => synthetic_frame(),
+    };
+
+    let handle = load_sam3_handle(
+        args.model_name,
+        &args.checkpoint_path,
+        candle_core::Device::Cpu,
+    )?;
+    let segmenter = CandleSam3ImageSegmenter {
+        handle: Arc::new(handle),
+    };
+    let prompt = PositivePointPrompt {
+        x: (frame.width / 2) as f32,
+        y: (frame.height / 2) as f32,
+    };
+    let mask = segmenter.segment(&frame, &[prompt]).await?;
+
+    if mask.width != frame.width || mask.height != frame.height {
+        return Err(format!(
+            "mask geometry {}x{} does not match input {}x{}",
+            mask.width, mask.height, frame.width, frame.height
+        )
+        .into());
+    }
+    if mask.pixels.len() != frame.width * frame.height {
+        return Err("mask pixel count does not match frame geometry".into());
+    }
+
+    if let Some(mask_out) = args.mask_out {
+        write_mask_stack(&mask_out, &[mask]).await?;
+        println!("wrote mask {}", mask_out.display());
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Args {
+    checkpoint_path: PathBuf,
+    image_path: Option<PathBuf>,
+    mask_out: Option<PathBuf>,
+    model_name: String,
+}
+
+impl Args {
+    fn parse(mut args: impl Iterator<Item = String>) -> Result<Self, Box<dyn Error>> {
+        let mut checkpoint_path = None;
+        let mut image_path = None;
+        let mut mask_out = None;
+        let mut model_name = "medical_sam3".to_string();
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--checkpoint" => checkpoint_path = Some(next_path(&mut args, "--checkpoint")?),
+                "--image" => image_path = Some(next_path(&mut args, "--image")?),
+                "--mask-out" => mask_out = Some(next_path(&mut args, "--mask-out")?),
+                "--model-name" => {
+                    model_name = args
+                        .next()
+                        .ok_or_else(|| "--model-name requires a value".to_string())?;
+                }
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                value => return Err(format!("unknown argument: {value}").into()),
+            }
+        }
+
+        let checkpoint_path =
+            checkpoint_path.ok_or_else(|| "--checkpoint is required".to_string())?;
+
+        Ok(Self {
+            checkpoint_path,
+            image_path,
+            mask_out,
+            model_name,
+        })
+    }
+}
+
+fn next_path(
+    args: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> Result<PathBuf, Box<dyn Error>> {
+    args.next()
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("{flag} requires a path").into())
+}
+
+fn print_help() {
+    println!(
+        "Usage: sam3_checkpoint_smoke --checkpoint PATH [--image PATH] [--mask-out PATH] [--model-name NAME]"
+    );
+}
+
+fn synthetic_frame() -> ImageFrame {
+    let width = 32usize;
+    let height = 32usize;
+    let mut pixels = Vec::with_capacity(width * height * 3);
+    for y in 0..height {
+        for x in 0..width {
+            let inside = (8..24).contains(&x) && (8..24).contains(&y);
+            let v = if inside { 220 } else { 32 };
+            pixels.extend_from_slice(&[v, v, v]);
+        }
+    }
+    ImageFrame {
+        width,
+        height,
+        channels: 3,
+        pixels,
+    }
+}
+
+fn load_image_frame(path: &Path) -> Result<ImageFrame, Box<dyn Error>> {
+    let image = image::ImageReader::open(path)?.decode()?.to_rgb8();
+    let (width, height) = image.dimensions();
+    Ok(ImageFrame {
+        width: width as usize,
+        height: height as usize,
+        channels: 3,
+        pixels: image.into_raw(),
+    })
+}

--- a/backend/tests/sam3_checkpoint_load.rs
+++ b/backend/tests/sam3_checkpoint_load.rs
@@ -1,0 +1,77 @@
+use std::{path::PathBuf, sync::Arc};
+
+use ouroboros_autoseg_plugin_backend::{
+    imaging::tiff_io::ImageFrame,
+    inference::{
+        candle_sam3::{load_sam3_handle, CandleSam3ImageSegmenter},
+        image::{ImageSegmenter, PositivePointPrompt},
+    },
+};
+
+#[tokio::test]
+#[ignore = "requires OUROBOROS_SAM3_CHECKPOINT pointing to a staged SAM3 checkpoint"]
+async fn sam3_medical_checkpoint_load() {
+    let Some(checkpoint_path) = checkpoint_from_env() else {
+        eprintln!("skipping: OUROBOROS_SAM3_CHECKPOINT is not set");
+        return;
+    };
+
+    let handle = load_sam3_handle(
+        "medical_sam3".to_string(),
+        &checkpoint_path,
+        candle_core::Device::Cpu,
+    )
+    .expect("checkpoint should load through the production Candle SAM3 source");
+
+    let frame = synthetic_frame();
+    let segmenter = CandleSam3ImageSegmenter {
+        handle: Arc::new(handle),
+    };
+    let mask = segmenter
+        .segment(
+            &frame,
+            &[PositivePointPrompt {
+                x: (frame.width / 2) as f32,
+                y: (frame.height / 2) as f32,
+            }],
+        )
+        .await
+        .expect("image path should produce a mask");
+
+    assert_eq!(mask.width, frame.width);
+    assert_eq!(mask.height, frame.height);
+    assert_eq!(mask.pixels.len(), frame.width * frame.height);
+    assert!(
+        mask.pixels.iter().all(|&value| value == 0 || value == 255),
+        "mask should use the established 0/255 convention"
+    );
+}
+
+fn checkpoint_from_env() -> Option<PathBuf> {
+    let path = std::env::var_os("OUROBOROS_SAM3_CHECKPOINT").map(PathBuf::from)?;
+    assert!(
+        path.is_file(),
+        "OUROBOROS_SAM3_CHECKPOINT must point to a checkpoint file: {}",
+        path.display()
+    );
+    Some(path)
+}
+
+fn synthetic_frame() -> ImageFrame {
+    let width = 32usize;
+    let height = 32usize;
+    let mut pixels = Vec::with_capacity(width * height * 3);
+    for y in 0..height {
+        for x in 0..width {
+            let inside = (8..24).contains(&x) && (8..24).contains(&y);
+            let v = if inside { 220 } else { 32 };
+            pixels.extend_from_slice(&[v, v, v]);
+        }
+    }
+    ImageFrame {
+        width,
+        height,
+        channels: 3,
+        pixels,
+    }
+}


### PR DESCRIPTION
## Summary

Adds checkpoint-load proof scaffolding for AUTO-2.

- adds an ignored integration test gated by `OUROBOROS_SAM3_CHECKPOINT`
- adds a `sam3_checkpoint_smoke` binary for checkpoint/image smoke checks
- documents the env var, command-line smoke path, and `0/255` mask convention

Stacked on #23.

Refs #18.

## Validation

- `cargo test` in `backend` passed: 49 tests, 1 ignored checkpoint test
- `cargo build --bin sam3_checkpoint_smoke` passed
- `cargo test --no-run --test sam3_checkpoint_load` passed
