### PR TITLE
[codex] Harden annotation metadata contract

### DIFF
--- a/backend/docs/annotation_metadata.md
+++ b/backend/docs/annotation_metadata.md
@@ -1,0 +1,30 @@
+# Straightened TIFF Annotation Metadata
+
+Ouroboros slicing output may include prompt seed points in the TIFF
+`ImageDescription` metadata under the `annotation_points` key. The plugin reads this
+metadata from the first page of a single-stack TIFF, or from the first TIFF in a
+directory-of-TIFF input.
+
+The value must be a non-empty array of `[x, y, z]` rows:
+
+```json
+{
+  "annotation_points": [
+    [128.0, 96.0, 0.0],
+    [127.5, 95.25, 12.0]
+  ]
+}
+```
+
+- `x`: pixel coordinate across the straightened slice width.
+- `y`: pixel coordinate across the straightened slice height.
+- `z`: frame or depth coordinate in the straightened stack.
+
+All coordinates are expressed in straightened-volume coordinates after Ouroboros
+projects the source annotation path into the sliced volume. They are not source
+scan coordinates.
+
+Missing `annotation_points` metadata means the plugin may use its configured
+fallback center prompts. Present but malformed `annotation_points` metadata is a
+bad request and must not silently fall back, because that would hide an invalid
+Ouroboros-to-plugin handoff.

--- a/backend/src/imaging/tiff_io.rs
+++ b/backend/src/imaging/tiff_io.rs
@@ -272,7 +272,7 @@ fn inspect_volume_sync(path: &Path) -> Result<VolumeInput, AppError> {
                 height: first_page.height,
                 width: first_page.width,
             },
-            annotation_points: parse_annotation_points(first_page.description.as_deref()),
+            annotation_points: parse_annotation_points(first_page.description.as_deref())?,
         })
     } else {
         let parsed = read_tiff_file(path)?;
@@ -288,7 +288,7 @@ fn inspect_volume_sync(path: &Path) -> Result<VolumeInput, AppError> {
                 height: first_page.height,
                 width: first_page.width,
             },
-            annotation_points: parse_annotation_points(first_page.description.as_deref()),
+            annotation_points: parse_annotation_points(first_page.description.as_deref())?,
         })
     }
 }
@@ -338,28 +338,78 @@ fn matches_tiff_extension(path: &Path) -> bool {
     )
 }
 
-fn parse_annotation_points(description: Option<&str>) -> Option<Vec<AnnotationPoint>> {
-    let description = description?;
-    let metadata: Value = serde_json::from_str(description).ok()?;
-    let rows = metadata.get("annotation_points")?.as_array()?;
+fn parse_annotation_points(
+    description: Option<&str>,
+) -> Result<Option<Vec<AnnotationPoint>>, AppError> {
+    let Some(description) = description.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let metadata: Value = match serde_json::from_str(description) {
+        Ok(value) => value,
+        Err(err) if description.contains("annotation_points") => {
+            return Err(annotation_metadata_error(format!(
+                "ImageDescription contains annotation_points but is not valid JSON: {err}"
+            )));
+        }
+        Err(_) => return Ok(None),
+    };
+    let Some(rows_value) = metadata.get("annotation_points") else {
+        return Ok(None);
+    };
+    let rows = rows_value.as_array().ok_or_else(|| {
+        annotation_metadata_error("annotation_points must be an array of [x, y, z] rows")
+    })?;
     if rows.is_empty() {
-        return None;
+        return Err(annotation_metadata_error(
+            "annotation_points must contain at least one [x, y, z] row",
+        ));
     }
 
     let mut points = Vec::with_capacity(rows.len());
-    for row in rows {
-        let values = row.as_array()?;
-        if values.len() < 3 {
-            return None;
+    for (row_index, row) in rows.iter().enumerate() {
+        let values = row.as_array().ok_or_else(|| {
+            annotation_metadata_error(format!(
+                "annotation_points[{row_index}] must be an [x, y, z] array"
+            ))
+        })?;
+        if values.len() != 3 {
+            return Err(annotation_metadata_error(format!(
+                "annotation_points[{row_index}] must contain exactly three coordinates: x, y, z"
+            )));
         }
         points.push(AnnotationPoint {
-            x: values[0].as_f64()? as f32,
-            y: values[1].as_f64()? as f32,
-            z: values[2].as_f64()? as f32,
+            x: parse_annotation_coordinate(&values[0], row_index, "x")?,
+            y: parse_annotation_coordinate(&values[1], row_index, "y")?,
+            z: parse_annotation_coordinate(&values[2], row_index, "z")?,
         });
     }
 
-    Some(points)
+    Ok(Some(points))
+}
+
+fn parse_annotation_coordinate(
+    value: &Value,
+    row_index: usize,
+    axis: &str,
+) -> Result<f32, AppError> {
+    let value = value.as_f64().ok_or_else(|| {
+        annotation_metadata_error(format!(
+            "annotation_points[{row_index}].{axis} must be a number"
+        ))
+    })? as f32;
+    if !value.is_finite() {
+        return Err(annotation_metadata_error(format!(
+            "annotation_points[{row_index}].{axis} must be finite"
+        )));
+    }
+    Ok(value)
+}
+
+fn annotation_metadata_error(message: impl Into<String>) -> AppError {
+    AppError::bad_request(format!(
+        "Malformed annotation_points metadata: {}",
+        message.into()
+    ))
 }
 
 fn read_tiff_file(path: &Path) -> Result<ParsedTiff, AppError> {

--- a/backend/src/imaging/tiff_io/tests.rs
+++ b/backend/src/imaging/tiff_io/tests.rs
@@ -47,6 +47,70 @@ async fn inspect_volume_reads_geometry_and_metadata_from_single_file() {
 }
 
 #[tokio::test]
+async fn inspect_volume_rejects_malformed_annotation_metadata_from_single_file() {
+    let root = unique_temp_dir();
+    let stack_path = root.join("stack.tif");
+    write_tiff_pages(
+        &stack_path,
+        &[WritableTiffPage {
+            width: 2,
+            height: 2,
+            channels: 1,
+            pixels: vec![0, 1, 2, 3],
+            description: Some(r#"{"annotation_points": [[1.0, 2.0]]}"#.to_string()),
+        }],
+    )
+    .expect("write stack");
+
+    let err = inspect_volume(&stack_path)
+        .await
+        .expect_err("malformed metadata should be rejected");
+    assert!(
+        err.to_string()
+            .contains("Malformed annotation_points metadata"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn inspect_volume_rejects_malformed_annotation_metadata_from_directory() {
+    let root = unique_temp_dir();
+    let frame_dir = root.join("frames");
+    std::fs::create_dir_all(&frame_dir).expect("create frame dir");
+    write_tiff_pages(
+        &frame_dir.join("00.tif"),
+        &[WritableTiffPage {
+            width: 2,
+            height: 2,
+            channels: 1,
+            pixels: vec![0, 1, 2, 3],
+            description: Some(r#"{"annotation_points": "center"}"#.to_string()),
+        }],
+    )
+    .expect("write malformed frame");
+    write_tiff_pages(
+        &frame_dir.join("01.tif"),
+        &[WritableTiffPage {
+            width: 2,
+            height: 2,
+            channels: 1,
+            pixels: vec![4, 5, 6, 7],
+            description: None,
+        }],
+    )
+    .expect("write frame");
+
+    let err = inspect_volume(&frame_dir)
+        .await
+        .expect_err("malformed metadata should be rejected");
+    assert!(
+        err.to_string()
+            .contains("Malformed annotation_points metadata"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
 async fn read_volume_frames_round_trips_written_tiff_pages() {
     let root = unique_temp_dir();
     let stack_path = root.join("stack.tif");


### PR DESCRIPTION
## Summary

- Reject malformed `annotation_points` metadata instead of silently falling back to generated center prompts.
- Cover malformed metadata for both single-stack TIFF inputs and directory-of-TIFF inputs.
- Document the straightened TIFF annotation metadata schema and `x, y, z` coordinate order.

## Stack

Stacked on #24.

## Verification

```bash
cargo test --manifest-path ouroboros_autoseg_plugin/backend/Cargo.toml inspect_volume
cargo test --manifest-path ouroboros_autoseg_plugin/backend/Cargo.toml annotations
cargo test --manifest-path ouroboros_autoseg_plugin/backend/Cargo.toml
rg -n "annotation_points" ouroboros/python/ouroboros
```

Refs #19.
