### PR TITLE
[codex] Harden SAM3 video smoke readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ checkpoint is downloaded and loaded.
 | Selector value | Display label | Checkpoint source | Stored checkpoint | Token required | Prompt support |
 | --- | --- | --- | --- | --- | --- |
 | `sam3` | SAM3 | Hugging Face `facebook/sam3`, file `sam3.pt` | `sam3.pt` | Yes | Image points, video points |
-| `medical_sam3` | Medical SAM3 | Hugging Face `ChongCong/Medical-SAM3`, file `checkpoint.pt` | `medical_sam3.pt` | No | Image points, video points |
+| `medical_sam3` | Medical SAM3 | Hugging Face `ChongCong/Medical-SAM3`, file `checkpoint_3D.pt` | `medical_sam3.pt` | No | Image points, video points |
 
 The `/model-status` endpoint reports `sam3` and `medical_sam3` only, matching
 the current production SAM3 surface. The `/download-model` endpoint stores

--- a/backend/app/util/config.py
+++ b/backend/app/util/config.py
@@ -37,7 +37,7 @@ SAM3_SOURCES = {
     },
     "medical_sam3": {
         "repo_id": "ChongCong/Medical-SAM3",
-        "filename": "checkpoint.pt",
+        "filename": "checkpoint_2D.pt",
         "requires_token": False,
     },
 }

--- a/backend/app/util/config.py
+++ b/backend/app/util/config.py
@@ -37,7 +37,7 @@ SAM3_SOURCES = {
     },
     "medical_sam3": {
         "repo_id": "ChongCong/Medical-SAM3",
-        "filename": "checkpoint_2D.pt",
+        "filename": "checkpoint_3D.pt",
         "requires_token": False,
     },
 }

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -1,0 +1,41 @@
+# SAM3 Video Smoke Checks
+
+AUTO-4 keeps the production video path on conservative runtime settings:
+
+- `VideoMemoryProfile::LowMemory`
+- no frame or state CPU offload
+- no prefetch ahead or behind
+- at most two feature cache entries
+
+The unit tests lock those options and validate that video propagation output has
+one mask per staged frame, with the same width and height as the straightened
+input volume.
+
+## Manual Biological-Stack Smoke
+
+After staging a SAM3 checkpoint and a small straightened stack with
+`annotation_points` metadata in the plugin volume, start the backend and submit a
+video job:
+
+```bash
+curl -X POST http://127.0.0.1:8686/process-stack \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "file_path": "/host/path/straightened-stack.tif",
+    "output_file": "/host/path/segmented.tif",
+    "model_type": "medical_sam3",
+    "predictor_type": "VideoPredictor",
+    "overlay_annotation_points": false
+  }'
+```
+
+Then poll `/status/{job_id}`. A valid smoke run should:
+
+- finish without frame-load panics or out-of-memory errors
+- preserve progress updates through polling or UI reconnects
+- write an output mask stack with the same frame count, width, and height as the
+  straightened input
+- keep normal output clean when `overlay_annotation_points` is false
+
+Use a separate run with `overlay_annotation_points` enabled when generating
+prompt-marker figure artifacts.

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -11,25 +11,32 @@ The unit tests lock those options and validate that video propagation output has
 one mask per staged frame, with the same width and height as the straightened
 input volume.
 
-## Manual Biological-Stack Smoke
+## GPU Biological-Stack Smoke
 
-After staging a SAM3 checkpoint and a small straightened stack with
-`annotation_points` metadata in the plugin volume, start the backend and submit a
-video job:
+Use the smoke script for the checkpoint/dataset-dependent portion of AUTO-4. It
+builds the CUDA backend target, verifies Docker GPU access, stages the input
+stack and Medical SAM3 3D checkpoint into the plugin Docker volume, submits a
+`VideoPredictor` request, polls the job, and verifies that the output mask stack
+is present.
 
 ```bash
-curl -X POST http://127.0.0.1:8686/process-stack \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "file_path": "/host/path/straightened-stack.tif",
-    "output_file": "/host/path/segmented.tif",
-    "model_type": "medical_sam3",
-    "predictor_type": "VideoPredictor",
-    "overlay_annotation_points": false
-  }'
+INPUT_STACK=local_data/psd_anno_thing.tif \
+  backend/scripts/biological_video_smoke_gpu.sh
 ```
 
-Then poll `/status/{job_id}`. A valid smoke run should:
+Useful overrides:
+
+```bash
+CHECKPOINT_PATH=/path/to/checkpoint_3D.pt \
+OUTPUT_DIR=/tmp/autoseg-smoke \
+HOST_PORT=18788 \
+  backend/scripts/biological_video_smoke_gpu.sh /path/to/straightened-stack.tif
+```
+
+The script defaults to
+`https://huggingface.co/ChongCong/Medical-SAM3/resolve/main/checkpoint_3D.pt`,
+because the video loader needs the tracker tensors present in the 3D Medical
+SAM3 checkpoint. A valid smoke run should:
 
 - finish without frame-load panics or out-of-memory errors
 - preserve progress updates through polling or UI reconnects

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+DEFAULT_CHECKPOINT_URL="https://huggingface.co/ChongCong/Medical-SAM3/resolve/main/checkpoint_3D.pt"
+DEFAULT_IMAGE="ouroboros-autoseg-backend:video-smoke-cuda"
+
+usage() {
+  cat <<'USAGE'
+Run the Medical SAM3 biological-stack video smoke on the CUDA backend.
+
+Usage:
+  INPUT_STACK=/path/to/straightened-stack.tif backend/scripts/biological_video_smoke_gpu.sh
+  backend/scripts/biological_video_smoke_gpu.sh /path/to/straightened-stack.tif
+
+Common options:
+  BUILD_IMAGE=0                 Use BACKEND_IMAGE instead of building this checkout.
+  BACKEND_IMAGE=name:tag         CUDA backend image to build/run.
+  CUDA_COMPUTE_CAP=75            CUDA compute capability used for the local image build.
+  CHECKPOINT_PATH=/path/model.pt Use an existing Medical SAM3 3D checkpoint.
+  CHECKPOINT_URL=https://...     Override the default checkpoint_3D.pt URL.
+  HOST_PORT=18788               Host port mapped to backend port 8686.
+  VOLUME_NAME=ouroboros-volume   Docker volume used as the plugin shared volume.
+  OUTPUT_NAME=mask_stack.tif     Output filename written under Segmentation/.
+  OUTPUT_DIR=/path/out           Also copy the output mask stack to this host dir.
+  KEEP_CONTAINER=1               Leave the backend container running after the script exits.
+
+The script builds/runs the CUDA Docker target with --gpus all, stages the input
+stack and Medical SAM3 3D checkpoint into the Docker volume, submits a
+VideoPredictor job, polls it to completion, and verifies that the mask stack was
+written. If Python tifffile is available, it also checks output geometry.
+USAGE
+}
+
+log() {
+  printf '[smoke] %s\n' "$*"
+}
+
+die() {
+  printf '[smoke] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+resolve_path() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+}
+
+json_value() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+value = payload
+for key in sys.argv[2].split("."):
+    value = value[key]
+print(value)
+PY
+}
+
+job_progress() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+steps = payload.get("steps", [])
+summary = ", ".join(
+    f"{step.get('name', '?')}={step.get('progress', '?')}%" for step in steps
+)
+print(summary or "no step progress")
+PY
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${VALIDATION_DIR:-}" && -d "${VALIDATION_DIR}" ]]; then
+    rm -rf "${VALIDATION_DIR}"
+  fi
+  if [[ "${KEEP_CONTAINER:-0}" != "1" ]]; then
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+  exit "${status}"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+INPUT_STACK="${INPUT_STACK:-${1:-}}"
+[[ -n "${INPUT_STACK}" ]] || {
+  usage
+  exit 2
+}
+
+require_command docker
+require_command curl
+require_command python3
+
+INPUT_STACK="$(resolve_path "${INPUT_STACK}")"
+[[ -f "${INPUT_STACK}" ]] || die "Input stack does not exist: ${INPUT_STACK}"
+
+BACKEND_IMAGE="${BACKEND_IMAGE:-${DEFAULT_IMAGE}}"
+BUILD_IMAGE="${BUILD_IMAGE:-1}"
+CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-75}"
+CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-770d20ca8db4f834ba4c89c845bca196fbfc97ea}"
+CHECKPOINT_URL="${CHECKPOINT_URL:-${DEFAULT_CHECKPOINT_URL}}"
+CHECKPOINT_CACHE="${CHECKPOINT_CACHE:-${XDG_CACHE_HOME:-${HOME}/.cache}/ouroboros-autoseg/medical_sam3_checkpoint_3D.pt}"
+HOST_PORT="${HOST_PORT:-18788}"
+VOLUME_NAME="${VOLUME_NAME:-ouroboros-volume}"
+CONTAINER_NAME="${CONTAINER_NAME:-ouroboros-autoseg-video-smoke}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-7200}"
+OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
+
+INPUT_DIR="$(dirname -- "${INPUT_STACK}")"
+INPUT_NAME="$(basename -- "${INPUT_STACK}")"
+INPUT_STEM="${INPUT_NAME%.*}"
+OUTPUT_NAME="${OUTPUT_NAME:-${INPUT_STEM}_video_smoke_mask.tif}"
+
+if [[ -n "${CHECKPOINT_PATH:-}" ]]; then
+  CHECKPOINT_PATH="$(resolve_path "${CHECKPOINT_PATH}")"
+  [[ -f "${CHECKPOINT_PATH}" ]] || die "Checkpoint does not exist: ${CHECKPOINT_PATH}"
+else
+  mkdir -p "$(dirname -- "${CHECKPOINT_CACHE}")"
+  if [[ ! -f "${CHECKPOINT_CACHE}" ]]; then
+    log "Downloading Medical SAM3 3D checkpoint"
+    curl_args=(-L --fail --continue-at - --output "${CHECKPOINT_CACHE}" "${CHECKPOINT_URL}")
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+      curl_args=(-H "Authorization: Bearer ${HF_TOKEN}" "${curl_args[@]}")
+    fi
+    curl "${curl_args[@]}"
+  else
+    log "Using cached checkpoint: ${CHECKPOINT_CACHE}"
+  fi
+  CHECKPOINT_PATH="${CHECKPOINT_CACHE}"
+fi
+
+CHECKPOINT_DIR="$(dirname -- "${CHECKPOINT_PATH}")"
+CHECKPOINT_NAME="$(basename -- "${CHECKPOINT_PATH}")"
+
+if [[ "${BUILD_IMAGE}" != "0" ]]; then
+  log "Building CUDA backend image: ${BACKEND_IMAGE}"
+  docker build \
+    -f "${BACKEND_DIR}/Dockerfile" \
+    --target cuda-runtime \
+    --build-arg CANDLE_FEATURES=cuda \
+    --build-arg CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP}" \
+    --build-arg CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT}" \
+    -t "${BACKEND_IMAGE}" \
+    "${BACKEND_DIR}"
+else
+  docker image inspect "${BACKEND_IMAGE}" >/dev/null 2>&1 \
+    || die "Docker image not found or Docker is not accessible: ${BACKEND_IMAGE}"
+fi
+
+if [[ "${SKIP_GPU_CHECK:-0}" != "1" ]]; then
+  log "Checking Docker GPU access with ${BACKEND_IMAGE}"
+  docker run --rm --gpus all --entrypoint nvidia-smi "${BACKEND_IMAGE}" >/dev/null
+fi
+
+log "Staging input and checkpoint in Docker volume: ${VOLUME_NAME}"
+docker volume create "${VOLUME_NAME}" >/dev/null
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -v "${INPUT_DIR}:/input:ro" \
+  -v "${CHECKPOINT_DIR}:/checkpoint:ro" \
+  -e INPUT_NAME="${INPUT_NAME}" \
+  -e CHECKPOINT_NAME="${CHECKPOINT_NAME}" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu '
+    plugin_root=/volume/sam3-segmentation
+    mkdir -p "${plugin_root}/chkpts" "${plugin_root}/Segmentation"
+    rm -f "${plugin_root}/${INPUT_NAME}" "${plugin_root}/Segmentation/${OUTPUT_NAME}"
+    cp "/input/${INPUT_NAME}" "${plugin_root}/${INPUT_NAME}"
+    cp "/checkpoint/${CHECKPOINT_NAME}" "${plugin_root}/chkpts/medical_sam3.pt"
+  '
+
+trap cleanup EXIT
+
+log "Starting CUDA backend container: ${CONTAINER_NAME}"
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --gpus all \
+  -p "127.0.0.1:${HOST_PORT}:8686" \
+  -v "${VOLUME_NAME}:/ouroboros-volume" \
+  -e VOLUME_MOUNT_PATH=/ouroboros-volume \
+  -e VOLUME_SERVER_URL=http://host.docker.internal:3001 \
+  --add-host host.docker.internal:host-gateway \
+  "${BACKEND_IMAGE}" >/dev/null
+
+log "Waiting for backend on http://127.0.0.1:${HOST_PORT}"
+for _ in $(seq 1 60); do
+  if curl -fs "http://127.0.0.1:${HOST_PORT}/" >/dev/null 2>&1; then
+    break
+  fi
+  if ! docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -qx true; then
+    docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+    die "Backend container exited before becoming ready"
+  fi
+  sleep 1
+done
+curl -fsS "http://127.0.0.1:${HOST_PORT}/" >/dev/null || die "Backend did not become ready"
+
+log "Submitting VideoPredictor smoke job"
+REQUEST_BODY="$(
+  python3 - "${INPUT_NAME}" "${OUTPUT_NAME}" "${OVERLAY_ANNOTATION_POINTS}" <<'PY'
+import json
+import sys
+
+input_name, output_name, overlay = sys.argv[1:4]
+print(json.dumps({
+    "file_path": f"/smoke/{input_name}",
+    "output_file": f"/smoke/{output_name}",
+    "model_type": "medical_sam3",
+    "predictor_type": "VideoPredictor",
+    "overlay_annotation_points": overlay.lower() == "true",
+}))
+PY
+)"
+SUBMIT_RESPONSE="$(
+  curl -fsS \
+    -X POST "http://127.0.0.1:${HOST_PORT}/process-stack" \
+    -H 'Content-Type: application/json' \
+    --data-binary "${REQUEST_BODY}"
+)"
+JOB_ID="$(json_value "${SUBMIT_RESPONSE}" "job_id")"
+log "Job accepted: ${JOB_ID}"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  sleep "${POLL_INTERVAL_SECONDS}"
+  STATUS_RESPONSE="$(curl -fsS "http://127.0.0.1:${HOST_PORT}/status/${JOB_ID}")"
+  JOB_STATUS="$(json_value "${STATUS_RESPONSE}" "status")"
+  log "status=${JOB_STATUS}; $(job_progress "${STATUS_RESPONSE}")"
+  case "${JOB_STATUS}" in
+    completed)
+      break
+      ;;
+    error)
+      docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+      die "Smoke job failed"
+      ;;
+  esac
+done
+
+[[ "${JOB_STATUS:-}" == "completed" ]] || {
+  docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+  die "Smoke job timed out after ${TIMEOUT_SECONDS}s"
+}
+
+log "Verifying output in Docker volume"
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu 'test -s "/volume/sam3-segmentation/Segmentation/${OUTPUT_NAME}"'
+
+VALIDATION_DIR="$(mktemp -d)"
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -v "${VALIDATION_DIR}:/out" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu 'cp "/volume/sam3-segmentation/Segmentation/${OUTPUT_NAME}" "/out/${OUTPUT_NAME}"'
+
+if python3 -c 'import tifffile' >/dev/null 2>&1; then
+  python3 - "${INPUT_STACK}" "${VALIDATION_DIR}/${OUTPUT_NAME}" <<'PY'
+import sys
+import tifffile
+
+
+def geometry(path):
+    with tifffile.TiffFile(path) as tif:
+        if not tif.pages:
+            raise SystemExit(f"{path} has no TIFF pages")
+        pages = len(tif.pages)
+        shape = tif.pages[0].shape
+        if len(shape) < 2:
+            raise SystemExit(f"{path} first page has unsupported shape {shape!r}")
+        return pages, int(shape[0]), int(shape[1])
+
+
+source = geometry(sys.argv[1])
+output = geometry(sys.argv[2])
+if source != output:
+    raise SystemExit(f"output geometry {output} does not match input {source}")
+print(f"[smoke] output geometry verified: frames={output[0]}, height={output[1]}, width={output[2]}")
+PY
+else
+  log "Python tifffile is not installed; skipped output geometry validation"
+fi
+
+if [[ -n "${OUTPUT_DIR:-}" ]]; then
+  mkdir -p "${OUTPUT_DIR}"
+  cp "${VALIDATION_DIR}/${OUTPUT_NAME}" "${OUTPUT_DIR}/${OUTPUT_NAME}"
+  log "Copied output to ${OUTPUT_DIR}/${OUTPUT_NAME}"
+fi
+
+log "GPU biological-stack smoke completed successfully"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -65,7 +65,7 @@ const MODEL_CATALOG: &[ModelDescriptor] = &[
         checkpoint_file: "medical_sam3.pt",
         download_source: DownloadSource::HuggingFace {
             repo: "ChongCong/Medical-SAM3",
-            filename: "checkpoint_2D.pt",
+            filename: "checkpoint_3D.pt",
             requires_token: false,
         },
     },

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -65,7 +65,7 @@ const MODEL_CATALOG: &[ModelDescriptor] = &[
         checkpoint_file: "medical_sam3.pt",
         download_source: DownloadSource::HuggingFace {
             repo: "ChongCong/Medical-SAM3",
-            filename: "checkpoint.pt",
+            filename: "checkpoint_2D.pt",
             requires_token: false,
         },
     },

--- a/backend/src/imaging/output.rs
+++ b/backend/src/imaging/output.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use crate::{
     error::AppError,
-    imaging::tiff_io::{write_tiff_pages, WritableTiffPage},
+    imaging::{
+        annotations::{interpolated_point_for_frame, AnnotationPoint},
+        overlay::draw_annotation_star,
+        tiff_io::{write_tiff_pages, WritableTiffPage},
+    },
     inference::image::FrameMask,
 };
 
@@ -40,6 +44,29 @@ pub async fn write_mask_stack(target: &Path, masks: &[FrameMask]) -> Result<(), 
         .collect::<Result<Vec<_>, _>>()?;
 
     write_tiff_pages(target, &pages)
+}
+
+pub async fn write_annotation_overlay_stack(
+    target: &Path,
+    masks: &[FrameMask],
+    annotation_points: &[AnnotationPoint],
+    intensity: u8,
+) -> Result<(), AppError> {
+    let mut overlay_masks = masks.to_vec();
+    for (frame_index, mask) in overlay_masks.iter_mut().enumerate() {
+        if let Some(point) = interpolated_point_for_frame(annotation_points, frame_index) {
+            draw_annotation_star(
+                &mut mask.pixels,
+                mask.width,
+                mask.height,
+                point.x,
+                point.y,
+                intensity,
+            );
+        }
+    }
+
+    write_mask_stack(target, &overlay_masks).await
 }
 
 #[cfg(test)]

--- a/backend/src/imaging/output/tests.rs
+++ b/backend/src/imaging/output/tests.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-use super::write_mask_stack;
+use super::{write_annotation_overlay_stack, write_mask_stack};
 use crate::{
+    imaging::annotations::AnnotationPoint,
     imaging::tiff_io::{inspect_volume, read_volume_frames},
     inference::image::FrameMask,
 };
@@ -71,4 +72,39 @@ async fn write_mask_stack_rejects_inconsistent_geometry() {
         error.to_string(),
         "Mask stack frames must all share the same geometry"
     );
+}
+
+#[tokio::test]
+async fn write_annotation_overlay_stack_preserves_source_masks_and_marks_points() {
+    let root = unique_temp_dir();
+    let output_path = root.join("mask-overlay.tif");
+    let masks = vec![
+        FrameMask {
+            width: 5,
+            height: 5,
+            pixels: vec![0; 25],
+        },
+        FrameMask {
+            width: 5,
+            height: 5,
+            pixels: vec![0; 25],
+        },
+    ];
+    let annotations = vec![AnnotationPoint {
+        x: 2.0,
+        y: 2.0,
+        z: 0.0,
+    }];
+
+    write_annotation_overlay_stack(&output_path, &masks, &annotations, 127)
+        .await
+        .expect("write overlay stack");
+
+    assert!(masks[0].pixels.iter().all(|pixel| *pixel == 0));
+    let frames = read_volume_frames(&output_path)
+        .await
+        .expect("read overlay stack");
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0].pixels[2 + 2 * 5], 127);
+    assert_eq!(frames[1].pixels[2 + 2 * 5], 127);
 }

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -136,15 +136,7 @@ fn run_video_inference(
 
     let source =
         sam3::VideoSource::from_path(frames_dir).map_err(|e| AppError::internal(e.to_string()))?;
-    let session_options = sam3::VideoSessionOptions {
-        tokenizer_path: None,
-        memory_profile: sam3::VideoMemoryProfile::LowMemory,
-        offload_frames_to_cpu: false,
-        offload_state_to_cpu: false,
-        prefetch_ahead: 0,
-        prefetch_behind: 0,
-        max_feature_cache_entries: 2,
-    };
+    let session_options = low_memory_video_session_options();
 
     let model_ref = &*handle.image_model;
     let tracker_ref = &*handle.tracker;
@@ -210,4 +202,37 @@ fn run_video_inference(
         .iter()
         .map(|frame| video_frame_to_mask(&frame.objects, frame_width, frame_height))
         .collect()
+}
+
+fn low_memory_video_session_options() -> sam3::VideoSessionOptions {
+    sam3::VideoSessionOptions {
+        tokenizer_path: None,
+        memory_profile: sam3::VideoMemoryProfile::LowMemory,
+        offload_frames_to_cpu: false,
+        offload_state_to_cpu: false,
+        prefetch_ahead: 0,
+        prefetch_behind: 0,
+        max_feature_cache_entries: 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_session_options_use_low_memory_no_prefetch_profile() {
+        let options = low_memory_video_session_options();
+
+        assert!(matches!(
+            options.memory_profile,
+            sam3::VideoMemoryProfile::LowMemory
+        ));
+        assert!(!options.offload_frames_to_cpu);
+        assert!(!options.offload_state_to_cpu);
+        assert_eq!(options.prefetch_ahead, 0);
+        assert_eq!(options.prefetch_behind, 0);
+        assert_eq!(options.max_feature_cache_entries, 2);
+        assert!(options.tokenizer_path.is_none());
+    }
 }

--- a/backend/src/services/checkpoints/tests.rs
+++ b/backend/src/services/checkpoints/tests.rs
@@ -165,7 +165,7 @@ fn medical_sam3_descriptor_uses_public_medical_checkpoint() {
             requires_token,
         } => {
             assert_eq!(repo, "ChongCong/Medical-SAM3");
-            assert_eq!(filename, "checkpoint.pt");
+            assert_eq!(filename, "checkpoint_2D.pt");
             assert!(!requires_token);
         }
         DownloadSource::PublicUrl(_) => panic!("medical_sam3 should use Hugging Face"),

--- a/backend/src/services/checkpoints/tests.rs
+++ b/backend/src/services/checkpoints/tests.rs
@@ -165,7 +165,7 @@ fn medical_sam3_descriptor_uses_public_medical_checkpoint() {
             requires_token,
         } => {
             assert_eq!(repo, "ChongCong/Medical-SAM3");
-            assert_eq!(filename, "checkpoint_2D.pt");
+            assert_eq!(filename, "checkpoint_3D.pt");
             assert!(!requires_token);
         }
         DownloadSource::PublicUrl(_) => panic!("medical_sam3 should use Hugging Face"),

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::{
     app_state::{AppState, Sam3ModelHandle},
@@ -9,7 +12,7 @@ use crate::{
             annotation_samples_for_video, default_annotations, interpolated_point_for_frame,
             AnnotationPoint, VolumeShape,
         },
-        output::write_mask_stack,
+        output::{write_annotation_overlay_stack, write_mask_stack},
         preprocess::{stage_input_frames, PreparedFrame, PreparedFrameEncoding},
         tiff_io::{inspect_volume, read_volume_frames, VolumeInput},
     },
@@ -132,6 +135,15 @@ pub async fn run(state: &AppState, job_id: &str, request: &ProcessRequest) -> Re
         tokio::fs::create_dir_all(parent).await?;
     }
     write_mask_stack(&prepared.plan.volume_output, &masks).await?;
+    if request.overlay_annotation_points {
+        write_annotation_overlay_stack(
+            &annotation_overlay_path(&prepared.plan.volume_output),
+            &masks,
+            &prepared.annotation_points,
+            request.annotation_overlay_intensity,
+        )
+        .await?;
+    }
     tokio::fs::remove_dir_all(&prepared.plan.temp_volume_dir).await?;
     state.update_job_step(job_id, 3, 100).await;
 
@@ -200,9 +212,44 @@ async fn run_video_predictor(
     };
     let video_prompts =
         annotation_samples_for_video(&prepared.annotation_points, prepared.staged_frames.len());
-    segmenter
+    let masks = segmenter
         .segment_video(&prepared.plan.temp_volume_dir, &video_prompts)
-        .await
+        .await?;
+    validate_video_masks(&masks, prepared)?;
+    Ok(masks)
+}
+
+fn validate_video_masks(
+    masks: &[FrameMask],
+    prepared: &PreparedPipelineInput,
+) -> Result<(), AppError> {
+    let expected_frames = prepared.staged_frames.len();
+    if masks.len() != expected_frames {
+        return Err(AppError::upstream(format!(
+            "Video inference returned {} masks for {expected_frames} staged frames",
+            masks.len()
+        )));
+    }
+
+    let expected_width = prepared.volume.geometry.width;
+    let expected_height = prepared.volume.geometry.height;
+    for (index, mask) in masks.iter().enumerate() {
+        if mask.width != expected_width || mask.height != expected_height {
+            return Err(AppError::upstream(format!(
+                "Video inference mask {index} has geometry {}x{}, expected {expected_width}x{expected_height}",
+                mask.width, mask.height
+            )));
+        }
+        if mask.pixels.len() != expected_width * expected_height {
+            return Err(AppError::upstream(format!(
+                "Video inference mask {index} has {} pixels, expected {}",
+                mask.pixels.len(),
+                expected_width * expected_height
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn frame_name_width(frame_count: usize) -> usize {
@@ -217,6 +264,18 @@ fn stage_encoding(predictor_type: &str) -> Result<PreparedFrameEncoding, AppErro
             "Unknown predictor type: {other}"
         ))),
     }
+}
+
+fn annotation_overlay_path(output_path: &Path) -> PathBuf {
+    let extension = output_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("tif");
+    let stem = output_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("segmentation");
+    output_path.with_file_name(format!("{stem}_annotation_overlay.{extension}"))
 }
 
 #[cfg(test)]

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -177,12 +177,33 @@ async fn model_handle_for_request(
 
     let model_name = descriptor.model_name.to_string();
     let handle = tokio::task::spawn_blocking(move || {
-        load_sam3_handle(model_name, &checkpoint_path, candle_core::Device::Cpu)
+        let device = inference_device()?;
+        load_sam3_handle(model_name, &checkpoint_path, device)
     })
     .await
     .map_err(|e| AppError::internal(e.to_string()))??;
 
     Ok(state.set_sam3_handle(handle).await)
+}
+
+fn inference_device() -> Result<candle_core::Device, AppError> {
+    #[cfg(feature = "cuda")]
+    {
+        let ordinal = std::env::var("CUDA_DEVICE_ORDINAL")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        candle_core::Device::new_cuda(ordinal).map_err(|error| {
+            AppError::internal(format!(
+                "CUDA backend was requested but device {ordinal} is unavailable: {error}"
+            ))
+        })
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        Ok(candle_core::Device::Cpu)
+    }
 }
 
 async fn run_image_predictor(

--- a/backend/src/services/pipeline/tests.rs
+++ b/backend/src/services/pipeline/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::{plan, prepare, run};
+use super::{annotation_overlay_path, plan, prepare, run, validate_video_masks};
 use crate::{
     app_state::AppState,
     config::AppConfig,
@@ -9,6 +9,7 @@ use crate::{
         preprocess::PreparedFrameEncoding,
         tiff_io::{write_tiff_pages, WritableTiffPage},
     },
+    inference::image::FrameMask,
 };
 use uuid::Uuid;
 
@@ -152,6 +153,102 @@ async fn prepare_generates_default_annotations_for_missing_metadata() {
 }
 
 #[tokio::test]
+async fn validate_video_masks_accepts_expected_frame_count_and_geometry() {
+    let root = unique_temp_dir();
+    let state = test_state(root.clone());
+    let plugin_root = state.config().plugin_root();
+    std::fs::create_dir_all(&plugin_root).expect("create plugin root");
+    write_input_volume(&plugin_root.join("input-stack.tif"), None);
+    let prepared = prepare(&state, &sample_request("VideoPredictor"))
+        .await
+        .expect("prepare pipeline input");
+    let masks = vec![
+        FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![0; 8],
+        },
+        FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![255; 8],
+        },
+    ];
+
+    validate_video_masks(&masks, &prepared).expect("valid video masks");
+}
+
+#[tokio::test]
+async fn validate_video_masks_rejects_frame_count_geometry_and_pixels() {
+    let root = unique_temp_dir();
+    let state = test_state(root.clone());
+    let plugin_root = state.config().plugin_root();
+    std::fs::create_dir_all(&plugin_root).expect("create plugin root");
+    write_input_volume(&plugin_root.join("input-stack.tif"), None);
+    let prepared = prepare(&state, &sample_request("VideoPredictor"))
+        .await
+        .expect("prepare pipeline input");
+
+    let frame_count_error = validate_video_masks(
+        &[FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![0; 8],
+        }],
+        &prepared,
+    )
+    .expect_err("frame count mismatch");
+    assert!(
+        frame_count_error
+            .to_string()
+            .contains("returned 1 masks for 2 staged frames"),
+        "{frame_count_error}"
+    );
+
+    let geometry_error = validate_video_masks(
+        &[
+            FrameMask {
+                width: 3,
+                height: 2,
+                pixels: vec![0; 6],
+            },
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 8],
+            },
+        ],
+        &prepared,
+    )
+    .expect_err("geometry mismatch");
+    assert!(
+        geometry_error.to_string().contains("expected 4x2"),
+        "{geometry_error}"
+    );
+
+    let pixel_error = validate_video_masks(
+        &[
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 7],
+            },
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 8],
+            },
+        ],
+        &prepared,
+    )
+    .expect_err("pixel length mismatch");
+    assert!(
+        pixel_error.to_string().contains("has 7 pixels, expected 8"),
+        "{pixel_error}"
+    );
+}
+
+#[tokio::test]
 async fn run_requires_downloaded_sam3_checkpoint_before_staging() {
     let root = unique_temp_dir();
     let state = test_state(root.clone());
@@ -169,4 +266,12 @@ async fn run_requires_downloaded_sam3_checkpoint_before_staging() {
     );
     // Staging should not have happened since the model availability check is first.
     assert!(!plugin_root.join("input-stack_temp").exists());
+}
+
+#[test]
+fn annotation_overlay_path_keeps_primary_output_clean() {
+    assert_eq!(
+        annotation_overlay_path(Path::new("/tmp/Segmentation/segmented.tif")),
+        PathBuf::from("/tmp/Segmentation/segmented_annotation_overlay.tif")
+    );
 }

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -126,7 +126,7 @@ class NetworkTests(unittest.TestCase):
 
         mocked_download.assert_called_once_with(
             repo_id="ChongCong/Medical-SAM3",
-            filename="checkpoint_2D.pt",
+            filename="checkpoint_3D.pt",
             token=None,
         )
         mocked_copy.assert_called_once_with("/tmp/cached-medical-sam3.pt", "/tmp/medical_sam3.pt")

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -126,7 +126,7 @@ class NetworkTests(unittest.TestCase):
 
         mocked_download.assert_called_once_with(
             repo_id="ChongCong/Medical-SAM3",
-            filename="checkpoint.pt",
+            filename="checkpoint_2D.pt",
             token=None,
         )
         mocked_copy.assert_called_once_with("/tmp/cached-medical-sam3.pt", "/tmp/medical_sam3.pt")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -203,7 +203,16 @@ export default defineConfig({
 					dest: '.'
 				},
 				{
-					src: 'backend/*',
+					src: [
+						'backend/.dockerignore',
+						'backend/Cargo.lock',
+						'backend/Cargo.toml',
+						'backend/Dockerfile',
+						'backend/compose.gpu.yml',
+						'backend/compose.yml',
+						'backend/docs',
+						'backend/src'
+					],
 					dest: '.'
 				}
 			]


### PR DESCRIPTION
## Summary

- Lock the production SAM3 video session to the intended low-memory/no-prefetch settings with unit coverage.
- Validate video propagation output immediately after inference: one mask per staged frame, matching geometry, and correct pixel count.
- Wire `overlay_annotation_points` to a separate `{stem}_annotation_overlay.{ext}` artifact so normal output remains clean.
- Add `backend/scripts/biological_video_smoke_gpu.sh`, a user-runnable CUDA smoke harness that builds/runs the CUDA backend target with `--gpus all`, stages the biological stack and Medical SAM3 checkpoint into the plugin Docker volume, submits a `VideoPredictor` job, polls status, and verifies the output mask stack.
- Make the Medical SAM3 download source use `checkpoint_3D.pt`, matching the checkpoint namespace required by the current Rust video loader.
- Select `Device::new_cuda(0)` when the backend is built with the `cuda` feature, with `CUDA_DEVICE_ORDINAL` available as an override. CPU builds still use `Device::Cpu`.
- Fix frontend packaging so `npm run build` no longer copies `backend/target` into `dist`; the bundle drops from 13 GB to 652 KB and exits cleanly.
- Add `target` to `backend/.dockerignore` so local compiled artifacts do not enter Docker build contexts.

## Stack

Rebased onto `main`.

## Verification

```bash
bash -n backend/scripts/biological_video_smoke_gpu.sh
backend/scripts/biological_video_smoke_gpu.sh --help
cargo test --manifest-path backend/Cargo.toml checkpoints
cargo test --manifest-path backend/Cargo.toml pipeline
PYTHONPATH=/home/dnorthover/ChengCode/ouroboros_autoseg_plugin poetry run pytest tests/util/test_network.py
docker build -f backend/Dockerfile --target cuda-runtime --build-arg CANDLE_FEATURES=cuda --build-arg CUDA_COMPUTE_CAP=75 -t ouroboros-autoseg-backend:video-smoke-cuda-check backend
docker run --rm --gpus all --entrypoint nvidia-smi ouroboros-autoseg-backend:video-smoke-cuda-check
```

`cargo fmt --manifest-path backend/Cargo.toml --check` was also attempted, but it fails on pre-existing formatting drift in `backend/src/inference/candle_sam3_helpers.rs` and `backend/src/inference/candle_sam3_helpers/tests.rs`, outside this PR's changed lines.

## Biological-Stack Smoke, 2026-06-26

Input stack:

- `/home/dnorthover/ChengCode/local_data/psd_anno_thing.tif`
- 4,901 pages, `200x200x1`, `uint16`
- embedded `annotation_points`: 50 rows
- point metadata is finite/in-bounds, with z spanning `0..4900`
- Rust reader smoke passed previously: `inspect_volume` found 50 points and `read_volume_frames` decoded all 4,901 frames

Checkpoint/runtime:

- checkpoint: `/tmp/ouroboros-volume/sam3-segmentation/chkpts/medical_sam3_3d.pt`
- CUDA image: `ouroboros-autoseg-backend:video-smoke-cuda-check`
- GPU check passed inside Docker on a Quadro RTX 5000 with Max-Q Design, 16 GB VRAM

Command:

```bash
INPUT_STACK=/home/dnorthover/ChengCode/local_data/psd_anno_thing.tif \
CHECKPOINT_PATH=/tmp/ouroboros-volume/sam3-segmentation/chkpts/medical_sam3_3d.pt \
BUILD_IMAGE=0 \
BACKEND_IMAGE=ouroboros-autoseg-backend:video-smoke-cuda-check \
VOLUME_NAME=ouroboros-autoseg-video-smoke-volume \
OUTPUT_DIR=/tmp/autoseg-smoke-output \
POLL_INTERVAL_SECONDS=30 \
TIMEOUT_SECONDS=7200 \
  backend/scripts/biological_video_smoke_gpu.sh
```

Result:

- script passed Docker GPU access validation
- backend accepted job `8ec3d8ad-25a4-44bf-afa4-4ce475250702`
- model load and frame staging progressed to `Inference=30`
- full-stack inference failed with `DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")`
- generated smoke-only Docker volume was removed after the failed run; original stack/checkpoint files were not modified

## Remaining Blocker

The full biological-stack acceptance smoke is now scripted and reproducible, but it still does **not** pass on the available 16 GB GPU. Issue #20 remains blocked on either reducing peak CUDA memory for the full 4,901-frame video path, adding chunked/windowed processing, or validating on a larger GPU.

Refs #20.
