### PR TITLE
[codex] Align dev compose with Rust backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,22 @@ To get started with developing a plugin:
 
 5. In the main app, go to the first menu dropdown and open the plugin manager. Click the plus, and paste the URL of your plugin (something like `http://localhost:5172`) in the development plugin option.
 
-### Backend Hot Reload (Docker Dev)
+### Backend Development Docker
 
-`npm run dev-backend` now uses backend dev compose files with:
+`npm run dev-backend` uses backend dev compose files with:
 
-- bind-mounted backend source (`backend/app -> /app/app`)
-- `uvicorn --reload` for live Python code reload
-- conditional Docker rebuilds only when one of these files changes:
-  - `backend/pyproject.toml`
-  - `backend/poetry.lock`
+- Rust backend compose files selected by local hardware:
+  - `backend/compose.dev.yml` when no NVIDIA GPU is detected
+  - `backend/compose.gpu.dev.yml` when `nvidia-smi` is available
+- conditional Docker rebuilds only when backend build inputs change:
   - `backend/Dockerfile`
+  - `backend/Cargo.toml`
+  - `backend/Cargo.lock`
+  - `backend/src`
+  - `backend/tests`
+  - backend compose files
 
-So normal source edits do not trigger a full image rebuild.
+Frontend-only edits do not trigger a backend image rebuild. Rust backend edits do rebuild the image because the release-style container compiles the Rust server into the runtime image.
 
 ### `package.json`
 

--- a/backend-dev.cjs
+++ b/backend-dev.cjs
@@ -2,13 +2,24 @@ const { upAll, downAll } = require('docker-compose')
 const { join } = require('path')
 const { execSync } = require('child_process')
 const { createHash } = require('crypto')
-const { existsSync, readFileSync, writeFileSync } = require('fs')
+const { existsSync, readFileSync, readdirSync, statSync, writeFileSync } = require('fs')
 
 const containerFolder = join(__dirname, 'backend')
 const statusFile = join(__dirname, '.docker-build-status.json')
 const serviceName = 'our_autoseg'
 const sessionId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
-const dependencyFiles = ['Dockerfile', 'pyproject.toml', 'poetry.lock']
+const dependencyPaths = [
+    '.dockerignore',
+    'Cargo.lock',
+    'Cargo.toml',
+    'Dockerfile',
+    'compose.dev.yml',
+    'compose.gpu.dev.yml',
+    'compose.gpu.yml',
+    'compose.yml',
+    'src',
+    'tests'
+]
 
 function fileHash(path) {
     const hash = createHash('sha256')
@@ -18,18 +29,33 @@ function fileHash(path) {
 
 function computeDependencyHash() {
     const hash = createHash('sha256')
-    for (const file of dependencyFiles) {
-        const filePath = join(containerFolder, file)
-        if (!existsSync(filePath)) {
-            hash.update(`${file}:missing`)
-            continue
-        }
-        hash.update(file)
-        hash.update(':')
-        hash.update(fileHash(filePath))
-        hash.update(';')
+    for (const dependencyPath of dependencyPaths) {
+        updatePathHash(hash, dependencyPath)
     }
     return hash.digest('hex')
+}
+
+function updatePathHash(hash, relativePath) {
+    const absolutePath = join(containerFolder, relativePath)
+    if (!existsSync(absolutePath)) {
+        hash.update(`${relativePath}:missing;`)
+        return
+    }
+
+    const stats = statSync(absolutePath)
+    if (stats.isDirectory()) {
+        hash.update(`${relativePath}:dir;`)
+        for (const child of readdirSync(absolutePath).sort()) {
+            updatePathHash(hash, `${relativePath}/${child}`)
+        }
+        return
+    }
+
+    if (stats.isFile()) {
+        hash.update(`${relativePath}:file:`)
+        hash.update(fileHash(absolutePath))
+        hash.update(';')
+    }
 }
 
 function readPreviousStatus() {

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -1,11 +1,9 @@
 services:
   our_autoseg:
     build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8686 --reload --reload-dir /app/app
     ports:
       - "8686:8686"
     volumes:
-      - ./app:/app/app
       - ouroboros-volume:/ouroboros-volume
     environment:
       - VOLUME_MOUNT_PATH=/ouroboros-volume

--- a/backend/compose.gpu.dev.yml
+++ b/backend/compose.gpu.dev.yml
@@ -1,17 +1,20 @@
 services:
   our_autoseg:
-    build: .
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8686 --reload --reload-dir /app/app
+    build:
+      context: .
+      args:
+        CANDLE_FEATURES: cuda
     ports:
       - "8686:8686"
     volumes:
-      - ./app:/app/app
       - ouroboros-volume:/ouroboros-volume
     environment:
       - VOLUME_MOUNT_PATH=/ouroboros-volume
       - VOLUME_SERVER_URL=http://host.docker.internal:3001
       # Frame loading mode: "sync" (safer, slower) or "async" (faster, may have threading issues)
       - SAM2_FRAME_LOADING_MODE=async
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     shm_size: 1gb
     deploy:
       resources:


### PR DESCRIPTION
## Summary

- align development compose files with the Rust backend instead of the vestigial Python/uvicorn backend command
- keep CPU and GPU dev compose startup on the Rust runtime container path
- make `backend-dev.cjs` hash Rust backend inputs recursively so frontend-only edits do not rebuild the backend, while Rust source/test/compose/Docker changes do
- update README wording from Python hot reload to Rust backend development rebuild behavior

Refs #28

## Validation

- `node --check backend-dev.cjs`
- `node_modules/.bin/tsc -b --pretty false`
- `docker compose -f backend/compose.dev.yml config`
- `docker compose -f backend/compose.gpu.dev.yml config`
- `git -C ouroboros_autoseg_plugin diff --check`

## Not run

- `npm run typecheck` is not defined in this repository.