### PR TITLE
[codex] Publish registry-backed backend images

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -1,0 +1,49 @@
+name: Publish Backend Image
+
+on:
+  push:
+    tags:
+      - v*.*.*
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: ghcr.io/chenglabresearch/ouroboros-autoseg-backend
+
+jobs:
+  backend-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and Push Backend Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -1,6 +1,11 @@
 name: Publish Backend Image
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/backend-image.yml
+      - backend/**
+      - README.md
   push:
     tags:
       - v*.*.*
@@ -11,7 +16,18 @@ env:
 
 jobs:
   backend-image:
+    name: Backend Image (${{ matrix.variant }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            target: runtime
+            tag_suffix: ''
+          - variant: cuda
+            target: cuda-runtime
+            tag_suffix: -cuda
     permissions:
       contents: read
       packages: write
@@ -24,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -35,15 +52,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          flavor: |
+            suffix=${{ matrix.tag_suffix }}
           tags: |
             type=ref,event=tag
             type=sha,prefix=sha-
 
-      - name: Build and Push Backend Image
+      - name: Build Backend Image
         uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile
-          push: true
+          target: ${{ matrix.target }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ The GPU compose files use a CUDA-specific Docker target:
 
 Those compose files select the `cuda-runtime` Docker target and pass `CANDLE_FEATURES=cuda`, which forwards the plugin crate's `cuda` feature to the Candle dependencies. Building these images requires an NVIDIA-capable Docker environment with the NVIDIA container toolkit available.
 
+### Registry Backend Images
+
+The `Publish Backend Image` workflow publishes the Rust backend image to GHCR for release tags and commit SHAs:
+
+- `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:<release-tag>`
+- `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-<commit>`
+
+The existing `backend/compose.yml` remains the local-build fallback. `backend/compose.registry.yml` is an opt-in packaged compose file for release builds that want to use a prebuilt immutable image by setting `OUROBOROS_AUTOSEG_BACKEND_IMAGE`.
+
 ### `package.json`
 
 The first lines of the package.json are important to identifying your plugin.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ The `Publish Backend Image` workflow publishes the Rust backend image to GHCR fo
 
 - `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:<release-tag>`
 - `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-<commit>`
+- `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:<release-tag>-cuda`
+- `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-<commit>-cuda`
 
-The existing `backend/compose.yml` remains the local-build fallback. `backend/compose.registry.yml` is an opt-in packaged compose file for release builds that want to use a prebuilt immutable image by setting `OUROBOROS_AUTOSEG_BACKEND_IMAGE`.
+The unsuffixed tags use the CPU runtime target, and the `-cuda` tags use the CUDA runtime target. The existing `backend/compose.yml` remains the local-build fallback. `backend/compose.registry.yml` is an opt-in packaged compose file for release builds that want to use a prebuilt immutable image by setting `OUROBOROS_AUTOSEG_BACKEND_IMAGE`.
 
 ### `package.json`
 

--- a/backend/compose.registry.yml
+++ b/backend/compose.registry.yml
@@ -1,0 +1,17 @@
+services:
+  our_autoseg:
+    image: ${OUROBOROS_AUTOSEG_BACKEND_IMAGE:?Set OUROBOROS_AUTOSEG_BACKEND_IMAGE to an immutable backend image tag}
+    ports:
+      - "8686:8686"
+    volumes:
+      - ouroboros-volume:/ouroboros-volume
+    environment:
+      - VOLUME_MOUNT_PATH=/ouroboros-volume
+      - VOLUME_SERVER_URL=http://host.docker.internal:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    shm_size: 1gb
+
+volumes:
+  ouroboros-volume:
+    external: true


### PR DESCRIPTION
## Summary

- add a `Publish Backend Image` workflow that builds and pushes the Rust backend Docker image to GHCR
- tag backend images by plugin release tag and commit SHA
- add `backend/compose.registry.yml` as an opt-in immutable-image compose path while keeping `backend/compose.yml` as the local-build fallback
- document registry-backed backend image usage

Closes #31

## Validation

- `env OUROBOROS_AUTOSEG_BACKEND_IMAGE=ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-test docker compose -f backend/compose.registry.yml config`
- `docker build -f backend/Dockerfile --target runtime -t ouroboros-autoseg-backend:pr32-cpu backend`
- `docker build -f backend/Dockerfile --target cuda-runtime --build-arg CANDLE_FEATURES=cuda --build-arg CUDA_COMPUTE_CAP=75 -t ouroboros-autoseg-backend:pr32-cuda backend`
- `git -C ouroboros_autoseg_plugin diff --check`
- GitHub Actions PR checks passed:
  - `Backend Image (cpu)`
  - `Backend Image (cuda)`

## Manual GHCR Publish

- Manually dispatched `Publish Backend Image` on `codex/registry-backend-images`
- Run: https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/actions/runs/28262424527
- Result: success
- Source commit: `f707038fb8ff9c499126b8167389f8127c2615ab`
- Published CPU image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-f707038`
- CPU digest: `sha256:02f6f542a3843c0dcadcbdf52e0d717856b23ca5a081bf390027c94c277983af`
- Published CUDA image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-f707038-cuda`
- CUDA digest: `sha256:e678b576ad8f3a1c93b94c84da3f4a1b1f9af15c7c800cd52169e3decfc81d44`
- GitHub Packages API confirms both tags exist
- Current GHCR package visibility: `public`
- Anonymous registry manifest inspection succeeds for both CPU and CUDA tags
