### PR TITLE
Finalize autoseg production packaging metadata

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -38,14 +38,18 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Build release layouts
-        run: npm run build:release
-
       - name: Set artifact names
         run: |
           safe_ref="${GITHUB_REF_NAME//\//-}"
           echo "CPU_ARTIFACT=auto-segmentation-${safe_ref}-cpu.zip" >> "$GITHUB_ENV"
           echo "CUDA_ARTIFACT=auto-segmentation-${safe_ref}-cuda.zip" >> "$GITHUB_ENV"
+          echo "OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Build release layouts
+        run: npm run build:release
+
+      - name: Validate release layouts
+        run: npm run validate:release
 
       - name: Archive CPU release
         working-directory: dist-artifacts/auto-segmentation-cpu

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Tagged releases publish two preinstallable plugin artifacts:
 - `auto-segmentation-<tag>-cpu.zip`
 - `auto-segmentation-<tag>-cuda.zip`
 
+The current production beta pin for Ouroboros package builds is:
+
+- tag: `v0.4.0-beta`
+- CPU asset: `auto-segmentation-v0.4.0-beta-cpu.zip`
+- CUDA asset: `auto-segmentation-v0.4.0-beta-cuda.zip`
+- CPU backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta`
+- CUDA backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta-cuda`
+
 Both archives unpack to the normal Ouroboros plugin folder layout, including
 `package.json`, `index.html`, `icon.svg`, `compose.yml`, frontend assets, and
 `plugin-release.json`. The CPU artifact `compose.yml` points at

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"dev": "concurrently 'npm run dev-frontend' 'npm run dev-backend'",
 		"build": "tsc -b && vite build",
 		"build:release": "npm run build && node scripts/prepare-release-artifacts.mjs",
+		"validate:release": "node scripts/validate-release-artifacts.mjs",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"
 	},

--- a/scripts/prepare-release-artifacts.mjs
+++ b/scripts/prepare-release-artifacts.mjs
@@ -5,11 +5,15 @@ const root = process.cwd()
 const dist = join(root, 'dist')
 const outputRoot = join(root, 'dist-artifacts')
 const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const releaseTag =
+	process.env.OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG ??
+	process.env.GITHUB_REF_NAME ??
+	`v${packageJson.version}`
 
 const imageRepository =
 	process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_REPOSITORY ??
 	'ghcr.io/chenglabresearch/ouroboros-autoseg-backend'
-const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? packageJson.version
+const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? releaseTag
 const cpuDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CPU_DIGEST ?? null
 const cudaDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CUDA_DIGEST ?? null
 
@@ -17,12 +21,14 @@ const variants = [
 	{
 		name: 'cpu',
 		directory: `${packageJson.name}-cpu`,
+		artifactName: artifactNameForVariant('cpu'),
 		image: imageReference('', cpuDigest),
 		cuda: false
 	},
 	{
 		name: 'cuda',
 		directory: `${packageJson.name}-cuda`,
+		artifactName: artifactNameForVariant('cuda'),
 		image: imageReference('-cuda', cudaDigest),
 		cuda: true
 	}
@@ -52,15 +58,28 @@ function manifestForVariant(variant) {
 		name: packageJson.name,
 		pluginName: packageJson.pluginName,
 		version: packageJson.version,
+		packageVersion: packageJson.version,
+		releaseTag,
+		artifactName: variant.artifactName,
 		variant: variant.name,
 		index: packageJson.index,
 		icon: packageJson.icon,
 		dockerCompose: packageJson.dockerCompose,
 		backendImage: variant.image,
+		backendImageRepository: imageRepository,
+		backendImageTag: imageTag,
 		cuda: variant.cuda,
 		commit: process.env.GITHUB_SHA ?? null,
 		ref: process.env.GITHUB_REF_NAME ?? null
 	}
+}
+
+function artifactNameForVariant(variantName) {
+	return `${packageJson.name}-${safeFilePart(releaseTag)}-${variantName}.zip`
+}
+
+function safeFilePart(value) {
+	return value.replaceAll('/', '-')
 }
 
 async function pruneBuildOnlyFiles(artifactRoot) {

--- a/scripts/validate-release-artifacts.mjs
+++ b/scripts/validate-release-artifacts.mjs
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const outputRoot = join(root, 'dist-artifacts')
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const releaseTag =
+	process.env.OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG ??
+	process.env.GITHUB_REF_NAME ??
+	`v${packageJson.version}`
+const imageRepository =
+	process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_REPOSITORY ??
+	'ghcr.io/chenglabresearch/ouroboros-autoseg-backend'
+const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? releaseTag
+const cpuDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CPU_DIGEST ?? null
+const cudaDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CUDA_DIGEST ?? null
+
+const variants = [
+	{
+		name: 'cpu',
+		directory: `${packageJson.name}-cpu`,
+		artifactName: artifactNameForVariant('cpu'),
+		image: imageReference('', cpuDigest),
+		cuda: false
+	},
+	{
+		name: 'cuda',
+		directory: `${packageJson.name}-cuda`,
+		artifactName: artifactNameForVariant('cuda'),
+		image: imageReference('-cuda', cudaDigest),
+		cuda: true
+	}
+]
+
+for (const variant of variants) {
+	const artifactRoot = join(outputRoot, variant.directory)
+	assert(existsSync(artifactRoot), `missing release layout: ${artifactRoot}`)
+
+	const pluginPackage = await readJson(join(artifactRoot, 'package.json'))
+	const manifest = await readJson(join(artifactRoot, 'plugin-release.json'))
+	const compose = await readFile(join(artifactRoot, 'compose.yml'), 'utf8')
+
+	assert(pluginPackage.name === packageJson.name, `${variant.name} package name mismatch`)
+	assert(pluginPackage.index === packageJson.index, `${variant.name} package index mismatch`)
+	assert(pluginPackage.dockerCompose === packageJson.dockerCompose, `${variant.name} compose path mismatch`)
+	assert(manifest.name === packageJson.name, `${variant.name} manifest name mismatch`)
+	assert(manifest.version === packageJson.version, `${variant.name} manifest version mismatch`)
+	assert(manifest.releaseTag === releaseTag, `${variant.name} release tag mismatch`)
+	assert(manifest.artifactName === variant.artifactName, `${variant.name} artifact name mismatch`)
+	assert(manifest.variant === variant.name, `${variant.name} manifest variant mismatch`)
+	assert(manifest.backendImage === variant.image, `${variant.name} backend image mismatch`)
+	assert(manifest.backendImageRepository === imageRepository, `${variant.name} repository mismatch`)
+	assert(manifest.backendImageTag === imageTag, `${variant.name} image tag mismatch`)
+	assert(manifest.cuda === variant.cuda, `${variant.name} CUDA flag mismatch`)
+	assert(compose.includes(`image: ${variant.image}`), `${variant.name} compose image mismatch`)
+
+	if (variant.cuda) {
+		assert(compose.includes('capabilities: [gpu]'), 'CUDA compose missing GPU reservation')
+	} else {
+		assert(!compose.includes('capabilities: [gpu]'), 'CPU compose should not reserve a GPU')
+	}
+}
+
+console.log(`Validated ${variants.length} release artifact layouts for ${releaseTag}.`)
+
+async function readJson(path) {
+	return JSON.parse(await readFile(path, 'utf8'))
+}
+
+function imageReference(suffix, digest) {
+	if (digest) return `${imageRepository}@${digest}`
+	return `${imageRepository}:${imageTag}${suffix}`
+}
+
+function artifactNameForVariant(variantName) {
+	return `${packageJson.name}-${safeFilePart(releaseTag)}-${variantName}.zip`
+}
+
+function safeFilePart(value) {
+	return value.replaceAll('/', '-')
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message)
+}


### PR DESCRIPTION
## Summary

Finalizes automatic segmentation plugin release metadata for Ouroboros production packaging.

- Records release tag, artifact name, backend image repository, and backend image tag in `plugin-release.json`.
- Adds a release layout validator for CPU and CUDA package artifacts.
- Runs validation in the plugin release workflow.
- Documents the `v0.4.0-beta` CPU/CUDA assets and GHCR backend image pins.

Addresses ChengLabResearch/ouroboros_autoseg_plugin#35.

## Validation

- `npm run build:release`
- `npm run validate:release`
- `node --check scripts/prepare-release-artifacts.mjs`
- `node --check scripts/validate-release-artifacts.mjs`
- `git diff --check`
