### PR TITLE
Finalize autoseg production packaging release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,6 +1,15 @@
 name: Build and Release Plugin
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/build-and-release.yml
+      - package.json
+      - scripts/**
+      - vite.config.ts
+      - src/**
+      - backend/**
+      - public/**
   push:
     tags:
       - v*.*.*
@@ -11,7 +20,7 @@ env:
 
 
 jobs:
-  release:
+  plugin-artifacts:
     runs-on: ubuntu-latest
 
     permissions:
@@ -19,28 +28,50 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install Dependencies
         run: npm install
 
-      - name: Build 
-        run: npm run build
+      - name: Build release layouts
+        run: npm run build:release
 
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
+      - name: Set artifact names
+        run: |
+          safe_ref="${GITHUB_REF_NAME//\//-}"
+          echo "CPU_ARTIFACT=auto-segmentation-${safe_ref}-cpu.zip" >> "$GITHUB_ENV"
+          echo "CUDA_ARTIFACT=auto-segmentation-${safe_ref}-cuda.zip" >> "$GITHUB_ENV"
+
+      - name: Archive CPU release
+        working-directory: dist-artifacts/auto-segmentation-cpu
+        run: zip -r "../${CPU_ARTIFACT}" .
+
+      - name: Archive CUDA release
+        working-directory: dist-artifacts/auto-segmentation-cuda
+        run: zip -r "../${CUDA_ARTIFACT}" .
+
+      - name: Upload CPU artifact for PR validation
+        uses: actions/upload-artifact@v4
         with:
-          type: 'zip'
-          filename: 'release.zip'
-          directory: 'dist'
+          name: ${{ env.CPU_ARTIFACT }}
+          path: dist-artifacts/${{ env.CPU_ARTIFACT }}
+
+      - name: Upload CUDA artifact for PR validation
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CUDA_ARTIFACT }}
+          path: dist-artifacts/${{ env.CUDA_ARTIFACT }}
 
       - name: Upload Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: "dist/release.zip"
+          artifacts: |
+            dist-artifacts/${{ env.CPU_ARTIFACT }}
+            dist-artifacts/${{ env.CUDA_ARTIFACT }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -38,14 +38,18 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Build release layouts
-        run: npm run build:release
-
       - name: Set artifact names
         run: |
           safe_ref="${GITHUB_REF_NAME//\//-}"
           echo "CPU_ARTIFACT=auto-segmentation-${safe_ref}-cpu.zip" >> "$GITHUB_ENV"
           echo "CUDA_ARTIFACT=auto-segmentation-${safe_ref}-cuda.zip" >> "$GITHUB_ENV"
+          echo "OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Build release layouts
+        run: npm run build:release
+
+      - name: Validate release layouts
+        run: npm run validate:release
 
       - name: Archive CPU release
         working-directory: dist-artifacts/auto-segmentation-cpu

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-artifacts
 dist-ssr
 *.local
 __pycache__

--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ To get started with developing a plugin:
 
 Frontend-only edits do not trigger a backend image rebuild. Rust backend edits do rebuild the image because the release-style container compiles the Rust server into the runtime image.
 
+### Production Plugin Artifacts
+
+Tagged releases publish two preinstallable plugin artifacts:
+
+- `auto-segmentation-<tag>-cpu.zip`
+- `auto-segmentation-<tag>-cuda.zip`
+
+Both archives unpack to the normal Ouroboros plugin folder layout, including
+`package.json`, `index.html`, `icon.svg`, `compose.yml`, frontend assets, and
+`plugin-release.json`. The CPU artifact `compose.yml` points at
+`ghcr.io/chenglabresearch/ouroboros-autoseg-backend:<tag>`. The CUDA artifact
+points at `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:<tag>-cuda` and
+includes the NVIDIA GPU device reservation.
+
+For production package preinstalls, unpack the selected artifact under
+`extra-resources/preinstalled-plugins/auto-segmentation/` before building the
+Ouroboros package.
+
 ### GPU Backend Images
 
 The GPU compose files use a CUDA-specific Docker target:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Tagged releases publish two preinstallable plugin artifacts:
 - `auto-segmentation-<tag>-cpu.zip`
 - `auto-segmentation-<tag>-cuda.zip`
 
+The current production beta pin for Ouroboros package builds is:
+
+- tag: `v0.4.0-beta`
+- CPU asset: `auto-segmentation-v0.4.0-beta-cpu.zip`
+- CUDA asset: `auto-segmentation-v0.4.0-beta-cuda.zip`
+- CPU backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta`
+- CUDA backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta-cuda`
+
 Both archives unpack to the normal Ouroboros plugin folder layout, including
 `package.json`, `index.html`, `icon.svg`, `compose.yml`, frontend assets, and
 `plugin-release.json`. The CPU artifact `compose.yml` points at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "auto-segmentation",
-	"version": "0.2.0",
+	"version": "0.4.0-beta",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "auto-segmentation",
-			"version": "0.2.0",
+			"version": "0.4.0-beta",
 			"dependencies": {
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"index": "./index.html",
 	"dockerCompose": "./compose.yml",
 	"private": true,
-	"version": "0.2.0",
+	"version": "0.4.0-beta",
 	"type": "module",
 	"main": "dist/main.js",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"dev-backend": "node backend-dev.cjs",
 		"dev": "concurrently 'npm run dev-frontend' 'npm run dev-backend'",
 		"build": "tsc -b && vite build",
+		"build:release": "npm run build && node scripts/prepare-release-artifacts.mjs",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"
 	},

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"dev": "concurrently 'npm run dev-frontend' 'npm run dev-backend'",
 		"build": "tsc -b && vite build",
 		"build:release": "npm run build && node scripts/prepare-release-artifacts.mjs",
+		"validate:release": "node scripts/validate-release-artifacts.mjs",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"
 	},

--- a/scripts/prepare-release-artifacts.mjs
+++ b/scripts/prepare-release-artifacts.mjs
@@ -1,0 +1,122 @@
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const dist = join(root, 'dist')
+const outputRoot = join(root, 'dist-artifacts')
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+
+const imageRepository =
+	process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_REPOSITORY ??
+	'ghcr.io/chenglabresearch/ouroboros-autoseg-backend'
+const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? packageJson.version
+const cpuDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CPU_DIGEST ?? null
+const cudaDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CUDA_DIGEST ?? null
+
+const variants = [
+	{
+		name: 'cpu',
+		directory: `${packageJson.name}-cpu`,
+		image: imageReference('', cpuDigest),
+		cuda: false
+	},
+	{
+		name: 'cuda',
+		directory: `${packageJson.name}-cuda`,
+		image: imageReference('-cuda', cudaDigest),
+		cuda: true
+	}
+]
+
+await mkdir(outputRoot, { recursive: true })
+
+for (const variant of variants) {
+	const artifactRoot = join(outputRoot, variant.directory)
+	await rm(artifactRoot, { recursive: true, force: true })
+	await cp(dist, artifactRoot, { recursive: true })
+	await pruneBuildOnlyFiles(artifactRoot)
+	await writeFile(join(artifactRoot, 'compose.yml'), composeForVariant(variant))
+	await writeFile(
+		join(artifactRoot, 'plugin-release.json'),
+		`${JSON.stringify(manifestForVariant(variant), null, 2)}\n`
+	)
+}
+
+function imageReference(suffix, digest) {
+	if (digest) return `${imageRepository}@${digest}`
+	return `${imageRepository}:${imageTag}${suffix}`
+}
+
+function manifestForVariant(variant) {
+	return {
+		name: packageJson.name,
+		pluginName: packageJson.pluginName,
+		version: packageJson.version,
+		variant: variant.name,
+		index: packageJson.index,
+		icon: packageJson.icon,
+		dockerCompose: packageJson.dockerCompose,
+		backendImage: variant.image,
+		cuda: variant.cuda,
+		commit: process.env.GITHUB_SHA ?? null,
+		ref: process.env.GITHUB_REF_NAME ?? null
+	}
+}
+
+async function pruneBuildOnlyFiles(artifactRoot) {
+	const buildOnlyPaths = [
+		'.dockerignore',
+		'Cargo.lock',
+		'Cargo.toml',
+		'Dockerfile',
+		'RUST_SCAFFOLD.md',
+		'app',
+		'compose.dev.yml',
+		'compose.gpu.dev.yml',
+		'compose.gpu.yml',
+		'compose.registry.yml',
+		'docs',
+		'poetry.lock',
+		'pyproject.toml',
+		'src',
+		'tests'
+	]
+
+	await Promise.all(
+		buildOnlyPaths.map((relativePath) =>
+			rm(join(artifactRoot, relativePath), { recursive: true, force: true })
+		)
+	)
+}
+
+function composeForVariant(variant) {
+	const gpuReservation = variant.cuda
+		? `    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+`
+		: ''
+
+	return `services:
+  our_autoseg:
+    image: ${variant.image}
+    ports:
+      - "8686:8686"
+    volumes:
+      - ouroboros-volume:/ouroboros-volume
+    environment:
+      - VOLUME_MOUNT_PATH=/ouroboros-volume
+      - VOLUME_SERVER_URL=http://host.docker.internal:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    shm_size: 1gb
+${gpuReservation}
+volumes:
+  ouroboros-volume:
+    external: true
+`
+}

--- a/scripts/prepare-release-artifacts.mjs
+++ b/scripts/prepare-release-artifacts.mjs
@@ -5,11 +5,15 @@ const root = process.cwd()
 const dist = join(root, 'dist')
 const outputRoot = join(root, 'dist-artifacts')
 const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const releaseTag =
+	process.env.OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG ??
+	process.env.GITHUB_REF_NAME ??
+	`v${packageJson.version}`
 
 const imageRepository =
 	process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_REPOSITORY ??
 	'ghcr.io/chenglabresearch/ouroboros-autoseg-backend'
-const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? process.env.GITHUB_REF_NAME ?? packageJson.version
+const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? releaseTag
 const cpuDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CPU_DIGEST ?? null
 const cudaDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CUDA_DIGEST ?? null
 
@@ -17,12 +21,14 @@ const variants = [
 	{
 		name: 'cpu',
 		directory: `${packageJson.name}-cpu`,
+		artifactName: artifactNameForVariant('cpu'),
 		image: imageReference('', cpuDigest),
 		cuda: false
 	},
 	{
 		name: 'cuda',
 		directory: `${packageJson.name}-cuda`,
+		artifactName: artifactNameForVariant('cuda'),
 		image: imageReference('-cuda', cudaDigest),
 		cuda: true
 	}
@@ -52,15 +58,28 @@ function manifestForVariant(variant) {
 		name: packageJson.name,
 		pluginName: packageJson.pluginName,
 		version: packageJson.version,
+		packageVersion: packageJson.version,
+		releaseTag,
+		artifactName: variant.artifactName,
 		variant: variant.name,
 		index: packageJson.index,
 		icon: packageJson.icon,
 		dockerCompose: packageJson.dockerCompose,
 		backendImage: variant.image,
+		backendImageRepository: imageRepository,
+		backendImageTag: imageTag,
 		cuda: variant.cuda,
 		commit: process.env.GITHUB_SHA ?? null,
 		ref: process.env.GITHUB_REF_NAME ?? null
 	}
+}
+
+function artifactNameForVariant(variantName) {
+	return `${packageJson.name}-${safeFilePart(releaseTag)}-${variantName}.zip`
+}
+
+function safeFilePart(value) {
+	return value.replaceAll('/', '-')
 }
 
 async function pruneBuildOnlyFiles(artifactRoot) {

--- a/scripts/validate-release-artifacts.mjs
+++ b/scripts/validate-release-artifacts.mjs
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const outputRoot = join(root, 'dist-artifacts')
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const releaseTag =
+	process.env.OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG ??
+	process.env.GITHUB_REF_NAME ??
+	`v${packageJson.version}`
+const imageRepository =
+	process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_REPOSITORY ??
+	'ghcr.io/chenglabresearch/ouroboros-autoseg-backend'
+const imageTag = process.env.OUROBOROS_AUTOSEG_BACKEND_IMAGE_TAG ?? releaseTag
+const cpuDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CPU_DIGEST ?? null
+const cudaDigest = process.env.OUROBOROS_AUTOSEG_BACKEND_CUDA_DIGEST ?? null
+
+const variants = [
+	{
+		name: 'cpu',
+		directory: `${packageJson.name}-cpu`,
+		artifactName: artifactNameForVariant('cpu'),
+		image: imageReference('', cpuDigest),
+		cuda: false
+	},
+	{
+		name: 'cuda',
+		directory: `${packageJson.name}-cuda`,
+		artifactName: artifactNameForVariant('cuda'),
+		image: imageReference('-cuda', cudaDigest),
+		cuda: true
+	}
+]
+
+for (const variant of variants) {
+	const artifactRoot = join(outputRoot, variant.directory)
+	assert(existsSync(artifactRoot), `missing release layout: ${artifactRoot}`)
+
+	const pluginPackage = await readJson(join(artifactRoot, 'package.json'))
+	const manifest = await readJson(join(artifactRoot, 'plugin-release.json'))
+	const compose = await readFile(join(artifactRoot, 'compose.yml'), 'utf8')
+
+	assert(pluginPackage.name === packageJson.name, `${variant.name} package name mismatch`)
+	assert(pluginPackage.index === packageJson.index, `${variant.name} package index mismatch`)
+	assert(pluginPackage.dockerCompose === packageJson.dockerCompose, `${variant.name} compose path mismatch`)
+	assert(manifest.name === packageJson.name, `${variant.name} manifest name mismatch`)
+	assert(manifest.version === packageJson.version, `${variant.name} manifest version mismatch`)
+	assert(manifest.releaseTag === releaseTag, `${variant.name} release tag mismatch`)
+	assert(manifest.artifactName === variant.artifactName, `${variant.name} artifact name mismatch`)
+	assert(manifest.variant === variant.name, `${variant.name} manifest variant mismatch`)
+	assert(manifest.backendImage === variant.image, `${variant.name} backend image mismatch`)
+	assert(manifest.backendImageRepository === imageRepository, `${variant.name} repository mismatch`)
+	assert(manifest.backendImageTag === imageTag, `${variant.name} image tag mismatch`)
+	assert(manifest.cuda === variant.cuda, `${variant.name} CUDA flag mismatch`)
+	assert(compose.includes(`image: ${variant.image}`), `${variant.name} compose image mismatch`)
+
+	if (variant.cuda) {
+		assert(compose.includes('capabilities: [gpu]'), 'CUDA compose missing GPU reservation')
+	} else {
+		assert(!compose.includes('capabilities: [gpu]'), 'CPU compose should not reserve a GPU')
+	}
+}
+
+console.log(`Validated ${variants.length} release artifact layouts for ${releaseTag}.`)
+
+async function readJson(path) {
+	return JSON.parse(await readFile(path, 'utf8'))
+}
+
+function imageReference(suffix, digest) {
+	if (digest) return `${imageRepository}@${digest}`
+	return `${imageRepository}:${imageTag}${suffix}`
+}
+
+function artifactNameForVariant(variantName) {
+	return `${packageJson.name}-${safeFilePart(releaseTag)}-${variantName}.zip`
+}
+
+function safeFilePart(value) {
+	return value.replaceAll('/', '-')
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -203,7 +203,13 @@ export default defineConfig({
 					dest: '.'
 				},
 				{
-					src: 'backend/*',
+					src: [
+						'backend/*',
+						'!backend/target',
+						'!backend/.venv',
+						'!backend/__pycache__',
+						'!backend/.pytest_cache'
+					],
 					dest: '.'
 				}
 			]


### PR DESCRIPTION
## Summary

Finalizes automatic segmentation plugin production packaging release metadata.

- Records release tag, artifact name, backend image repository, and backend image tag in release metadata.
- Adds CPU/CUDA release artifact validation.
- Runs release validation in CI.
- Documents the `v0.4.0-beta` CPU/CUDA assets and GHCR backend image pins.

Closes #35.

## Validation

- Fix-to-staging PR #36 passed.
- Staging smoke tag: `v0.4.0-beta-packaging-smoke.6`
- Build and Release Plugin run passed: https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/actions/runs/28620205585
- Publish Backend Image run passed: https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/actions/runs/28620205577
