### PR TITLE
CANDLE-2.1: restore reproducible CUDA Medical-SAM3 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ checkpoint is downloaded and loaded.
 | Selector value | Display label | Checkpoint source | Stored checkpoint | Token required | Prompt support |
 | --- | --- | --- | --- | --- | --- |
 | `sam3` | SAM3 | Hugging Face `facebook/sam3`, file `sam3.pt` | `sam3.pt` | Yes | Image points, video points |
-| `medical_sam3` | Medical SAM3 | Hugging Face `ChongCong/Medical-SAM3`, file `checkpoint.pt` | `medical_sam3.pt` | No | Image points, video points |
+| `medical_sam3` | Medical SAM3 | Hugging Face `ChongCong/Medical-SAM3`, file `checkpoint_3D.pt` | `medical_sam3.pt` | No | Image points, video points |
 
 The `/model-status` endpoint reports `sam3` and `medical_sam3` only, matching
 the current production SAM3 surface. The `/download-model` endpoint stores

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,9 @@ WORKDIR /build
 
 # Clone candle_sam3 at the pinned commit used during development.
 ARG CANDLE_SAM3_COMMIT=770d20ca8db4f834ba4c89c845bca196fbfc97ea
+ARG PLUGIN_GIT_SHA=unknown
+ENV CANDLE_SAM3_GIT_SHA=${CANDLE_SAM3_COMMIT}
+ENV PLUGIN_GIT_SHA=${PLUGIN_GIT_SHA}
 RUN git clone https://github.com/den-sq/candle_sam3.git candle_sam3_main \
     && git -C candle_sam3_main checkout "${CANDLE_SAM3_COMMIT}"
 
@@ -51,6 +54,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 WORKDIR /build
 
 ARG CANDLE_SAM3_COMMIT=770d20ca8db4f834ba4c89c845bca196fbfc97ea
+ARG PLUGIN_GIT_SHA=unknown
+ENV CANDLE_SAM3_GIT_SHA=${CANDLE_SAM3_COMMIT}
+ENV PLUGIN_GIT_SHA=${PLUGIN_GIT_SHA}
 RUN git clone https://github.com/den-sq/candle_sam3.git candle_sam3_main \
     && git -C candle_sam3_main checkout "${CANDLE_SAM3_COMMIT}"
 

--- a/backend/app/util/config.py
+++ b/backend/app/util/config.py
@@ -37,7 +37,7 @@ SAM3_SOURCES = {
     },
     "medical_sam3": {
         "repo_id": "ChongCong/Medical-SAM3",
-        "filename": "checkpoint.pt",
+        "filename": "checkpoint_2D.pt",
         "requires_token": False,
     },
 }

--- a/backend/app/util/config.py
+++ b/backend/app/util/config.py
@@ -37,7 +37,7 @@ SAM3_SOURCES = {
     },
     "medical_sam3": {
         "repo_id": "ChongCong/Medical-SAM3",
-        "filename": "checkpoint_2D.pt",
+        "filename": "checkpoint_3D.pt",
         "requires_token": False,
     },
 }

--- a/backend/docs/candle2_old_pin_baseline.md
+++ b/backend/docs/candle2_old_pin_baseline.md
@@ -1,0 +1,49 @@
+# CANDLE-2 old-pin Medical-SAM3 baseline
+
+Recorded 2026-07-18 for `den-sq/sam_parity#34` and the synchronized comparison
+required by `den-sq/sam_parity#40`.
+
+## Fixed inputs
+
+- Plugin: `c8d3c0218acde2c31f77f9a37d630368c83667cc`
+- Candle: `770d20ca8db4f834ba4c89c845bca196fbfc97ea`
+- CUDA image: `sha256:6361ad063e2f0d44757d53b2fc3284bb3395a8bc2f9c44c09199d795a4d0c12f`
+- GPU: Quadro RTX 5000 with Max-Q Design, compute capability 7.5
+- Driver / CUDA runtime: 581.60 / 12.4.1
+- Medical checkpoint: `checkpoint_3D.pt`, SHA-256 `6e40bbaa739ac44e3e47dc6355ef6dedc560a30411377ad891f8af9e6df0dbd6`
+- Fixture: first 16 pages of `psd_anno_thing.tif`, 16x200x200 `uint16`, with the frame-0 annotation retained as one tracked object
+- Fixture SHA-256: `48dd32e122e73582a0db13207384f34faa1578098e7e8578f2876084cea06796`
+
+## Results
+
+| Run | Elapsed | Throughput | Peak VRAM | Average GPU utilization | Peak container RSS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Cold | 92 s | 0.174 fps | 11,936 MiB | 70.8% | 333.7 MiB |
+| Warm | 98 s | 0.163 fps | 11,927 MiB | 64.2% | 325.7 MiB |
+
+Both runs passed the harness checks for CUDA device 0, exact plugin/Candle SHAs,
+16 output pages at 200x200, `uint8` output, and values restricted to 0 and 255.
+The cold and warm TIFF outputs were byte-identical with SHA-256
+`bf6d366d33adc09053ba6da7065c88916d6780a133bb2779204f458af751c67e`.
+
+The API remained at its static 30% inference marker during propagation. The
+separate frame-derived progress work remains in `den-sq/sam_parity#38`.
+
+## Reproduction
+
+Build the fixed CUDA control:
+
+```bash
+docker build -f backend/Dockerfile --target cuda-runtime \
+  --build-arg CANDLE_FEATURES=cuda \
+  --build-arg CUDA_COMPUTE_CAP=75 \
+  --build-arg CANDLE_SAM3_COMMIT=770d20ca8db4f834ba4c89c845bca196fbfc97ea \
+  --build-arg PLUGIN_GIT_SHA=c8d3c0218acde2c31f77f9a37d630368c83667cc \
+  -t ouroboros-autoseg-backend:candle2-baseline backend
+```
+
+Then run `backend/scripts/biological_video_smoke_gpu.sh` with
+`INPUT_STACK`, `CHECKPOINT_PATH`, and `ARTIFACT_DIR` set. The script records
+`revisions.env`, synchronized `telemetry.csv`, a bounded `backend.log`, and the
+validated output TIFF. Use the same fixture and settings with only
+`CANDLE_SAM3_COMMIT` changed for the CANDLE-2.2 comparison.

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -44,5 +44,12 @@ SAM3 checkpoint. A valid smoke run should:
   straightened input
 - keep normal output clean when `overlay_annotation_points` is false
 
+Each run writes a `revisions.env`, bounded `backend.log`, and synchronized
+`telemetry.csv` under `ARTIFACT_DIR` (or `OUTPUT_DIR` when set). The telemetry
+rows record elapsed time, GPU utilization, GPU memory, and container memory.
+The harness also verifies that the model-load log contains the requested CUDA
+ordinal plus the exact plugin and Candle revisions, and that every output TIFF
+page is `uint8` with binary values only.
+
 Use a separate run with `overlay_annotation_points` enabled when generating
 prompt-marker figure artifacts.

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -1,0 +1,41 @@
+# SAM3 Video Smoke Checks
+
+AUTO-4 keeps the production video path on conservative runtime settings:
+
+- `VideoMemoryProfile::LowMemory`
+- no frame or state CPU offload
+- no prefetch ahead or behind
+- at most two feature cache entries
+
+The unit tests lock those options and validate that video propagation output has
+one mask per staged frame, with the same width and height as the straightened
+input volume.
+
+## Manual Biological-Stack Smoke
+
+After staging a SAM3 checkpoint and a small straightened stack with
+`annotation_points` metadata in the plugin volume, start the backend and submit a
+video job:
+
+```bash
+curl -X POST http://127.0.0.1:8686/process-stack \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "file_path": "/host/path/straightened-stack.tif",
+    "output_file": "/host/path/segmented.tif",
+    "model_type": "medical_sam3",
+    "predictor_type": "VideoPredictor",
+    "overlay_annotation_points": false
+  }'
+```
+
+Then poll `/status/{job_id}`. A valid smoke run should:
+
+- finish without frame-load panics or out-of-memory errors
+- preserve progress updates through polling or UI reconnects
+- write an output mask stack with the same frame count, width, and height as the
+  straightened input
+- keep normal output clean when `overlay_annotation_points` is false
+
+Use a separate run with `overlay_annotation_points` enabled when generating
+prompt-marker figure artifacts.

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -11,25 +11,32 @@ The unit tests lock those options and validate that video propagation output has
 one mask per staged frame, with the same width and height as the straightened
 input volume.
 
-## Manual Biological-Stack Smoke
+## GPU Biological-Stack Smoke
 
-After staging a SAM3 checkpoint and a small straightened stack with
-`annotation_points` metadata in the plugin volume, start the backend and submit a
-video job:
+Use the smoke script for the checkpoint/dataset-dependent portion of AUTO-4. It
+builds the CUDA backend target, verifies Docker GPU access, stages the input
+stack and Medical SAM3 3D checkpoint into the plugin Docker volume, submits a
+`VideoPredictor` request, polls the job, and verifies that the output mask stack
+is present.
 
 ```bash
-curl -X POST http://127.0.0.1:8686/process-stack \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "file_path": "/host/path/straightened-stack.tif",
-    "output_file": "/host/path/segmented.tif",
-    "model_type": "medical_sam3",
-    "predictor_type": "VideoPredictor",
-    "overlay_annotation_points": false
-  }'
+INPUT_STACK=local_data/psd_anno_thing.tif \
+  backend/scripts/biological_video_smoke_gpu.sh
 ```
 
-Then poll `/status/{job_id}`. A valid smoke run should:
+Useful overrides:
+
+```bash
+CHECKPOINT_PATH=/path/to/checkpoint_3D.pt \
+OUTPUT_DIR=/tmp/autoseg-smoke \
+HOST_PORT=18788 \
+  backend/scripts/biological_video_smoke_gpu.sh /path/to/straightened-stack.tif
+```
+
+The script defaults to
+`https://huggingface.co/ChongCong/Medical-SAM3/resolve/main/checkpoint_3D.pt`,
+because the video loader needs the tracker tensors present in the 3D Medical
+SAM3 checkpoint. A valid smoke run should:
 
 - finish without frame-load panics or out-of-memory errors
 - preserve progress updates through polling or UI reconnects

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -27,6 +27,7 @@ Common options:
   OUTPUT_DIR=/path/out           Also copy the output mask stack to this host dir.
   ARTIFACT_DIR=/path/artifacts   Store revisions, telemetry, and bounded backend logs here.
   TELEMETRY_INTERVAL_SECONDS=1  Sampling interval for GPU, RSS, and elapsed-time CSV rows.
+  TIFF_VALIDATOR_PYTHON=python3  Python interpreter with tifffile and numpy installed.
   KEEP_CONTAINER=1               Leave the backend container running after the script exits.
 
 The script builds/runs the CUDA Docker target with --gpus all, stages the input
@@ -158,6 +159,12 @@ TELEMETRY_INTERVAL_SECONDS="${TELEMETRY_INTERVAL_SECONDS:-1}"
 CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL:-0}"
 LOG_TAIL_LINES="${LOG_TAIL_LINES:-500}"
 OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
+if [[ -x "${BACKEND_DIR}/.venv/bin/python" ]]; then
+  DEFAULT_TIFF_VALIDATOR_PYTHON="${BACKEND_DIR}/.venv/bin/python"
+else
+  DEFAULT_TIFF_VALIDATOR_PYTHON="python3"
+fi
+TIFF_VALIDATOR_PYTHON="${TIFF_VALIDATOR_PYTHON:-${DEFAULT_TIFF_VALIDATOR_PYTHON}}"
 
 INPUT_DIR="$(dirname -- "${INPUT_STACK}")"
 INPUT_NAME="$(basename -- "${INPUT_STACK}")"
@@ -352,9 +359,11 @@ docker run --rm \
   "${BACKEND_IMAGE}" \
   -ceu 'cp "/volume/sam3-segmentation/Segmentation/${OUTPUT_NAME}" "/out/${OUTPUT_NAME}"'
 
-if python3 -c 'import tifffile' >/dev/null 2>&1; then
-  python3 - "${INPUT_STACK}" "${VALIDATION_DIR}/${OUTPUT_NAME}" <<'PY'
+"${TIFF_VALIDATOR_PYTHON}" -c 'import numpy, tifffile' >/dev/null 2>&1 \
+  || die "TIFF validation requires numpy and tifffile in ${TIFF_VALIDATOR_PYTHON}"
+"${TIFF_VALIDATOR_PYTHON}" - "${INPUT_STACK}" "${VALIDATION_DIR}/${OUTPUT_NAME}" <<'PY'
 import sys
+import numpy
 import tifffile
 
 
@@ -378,14 +387,11 @@ with tifffile.TiffFile(sys.argv[2]) as tif:
         values = page.asarray()
         if values.dtype != "uint8":
             raise SystemExit(f"output page {index} has dtype {values.dtype}, expected uint8")
-        unique = set(int(value) for value in __import__("numpy").unique(values))
+        unique = set(int(value) for value in numpy.unique(values))
         if not unique.issubset({0, 255}):
             raise SystemExit(f"output page {index} is not binary: {sorted(unique)!r}")
 print(f"[smoke] output geometry verified: frames={output[0]}, height={output[1]}, width={output[2]}")
 PY
-else
-  log "Python tifffile is not installed; skipped output geometry validation"
-fi
 
 if [[ -n "${OUTPUT_DIR:-}" ]]; then
   mkdir -p "${OUTPUT_DIR}"

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -25,6 +25,8 @@ Common options:
   VOLUME_NAME=ouroboros-volume   Docker volume used as the plugin shared volume.
   OUTPUT_NAME=mask_stack.tif     Output filename written under Segmentation/.
   OUTPUT_DIR=/path/out           Also copy the output mask stack to this host dir.
+  ARTIFACT_DIR=/path/artifacts   Store revisions, telemetry, and bounded backend logs here.
+  TELEMETRY_INTERVAL_SECONDS=1  Sampling interval for GPU, RSS, and elapsed-time CSV rows.
   KEEP_CONTAINER=1               Leave the backend container running after the script exits.
 
 The script builds/runs the CUDA Docker target with --gpus all, stages the input
@@ -82,8 +84,36 @@ print(summary or "no step progress")
 PY
 }
 
+capture_backend_log() {
+  [[ -n "${ARTIFACT_DIR:-}" ]] || return 0
+  docker logs --tail "${LOG_TAIL_LINES}" "${CONTAINER_NAME}" \
+    >"${ARTIFACT_DIR}/backend.log" 2>&1 || true
+}
+
+telemetry_loop() {
+  local start_epoch="$1"
+  while docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -qx true; do
+    local now elapsed gpu rss
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    elapsed=$(( $(date +%s) - start_epoch ))
+    gpu="$(nvidia-smi \
+      --id="${CUDA_DEVICE_ORDINAL}" \
+      --query-gpu=index,utilization.gpu,memory.used,memory.total \
+      --format=csv,noheader,nounits 2>/dev/null | head -n 1 || true)"
+    rss="$(docker stats --no-stream --format '{{.MemUsage}}' "${CONTAINER_NAME}" 2>/dev/null || true)"
+    printf '%s,%s,%s,"%s"\n' "${now}" "${elapsed}" "${gpu}" "${rss}" \
+      >>"${TELEMETRY_CSV}"
+    sleep "${TELEMETRY_INTERVAL_SECONDS}"
+  done
+}
+
 cleanup() {
   local status=$?
+  if [[ -n "${TELEMETRY_PID:-}" ]]; then
+    kill "${TELEMETRY_PID}" >/dev/null 2>&1 || true
+    wait "${TELEMETRY_PID}" 2>/dev/null || true
+  fi
+  capture_backend_log
   if [[ -n "${VALIDATION_DIR:-}" && -d "${VALIDATION_DIR}" ]]; then
     rm -rf "${VALIDATION_DIR}"
   fi
@@ -115,6 +145,8 @@ BACKEND_IMAGE="${BACKEND_IMAGE:-${DEFAULT_IMAGE}}"
 BUILD_IMAGE="${BUILD_IMAGE:-1}"
 CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-75}"
 CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-770d20ca8db4f834ba4c89c845bca196fbfc97ea}"
+PLUGIN_GIT_SHA="${PLUGIN_GIT_SHA:-$(git -C "${BACKEND_DIR}/.." rev-parse HEAD)}"
+PLUGIN_DIRTY="$(git -C "${BACKEND_DIR}/.." status --porcelain | awk 'NF { found=1 } END { print found ? "true" : "false" }')"
 CHECKPOINT_URL="${CHECKPOINT_URL:-${DEFAULT_CHECKPOINT_URL}}"
 CHECKPOINT_CACHE="${CHECKPOINT_CACHE:-${XDG_CACHE_HOME:-${HOME}/.cache}/ouroboros-autoseg/medical_sam3_checkpoint_3D.pt}"
 HOST_PORT="${HOST_PORT:-18788}"
@@ -122,12 +154,20 @@ VOLUME_NAME="${VOLUME_NAME:-ouroboros-volume}"
 CONTAINER_NAME="${CONTAINER_NAME:-ouroboros-autoseg-video-smoke}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-7200}"
+TELEMETRY_INTERVAL_SECONDS="${TELEMETRY_INTERVAL_SECONDS:-1}"
+CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL:-0}"
+LOG_TAIL_LINES="${LOG_TAIL_LINES:-500}"
 OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
 
 INPUT_DIR="$(dirname -- "${INPUT_STACK}")"
 INPUT_NAME="$(basename -- "${INPUT_STACK}")"
 INPUT_STEM="${INPUT_NAME%.*}"
 OUTPUT_NAME="${OUTPUT_NAME:-${INPUT_STEM}_video_smoke_mask.tif}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${OUTPUT_DIR:-/tmp/autoseg-smoke-${INPUT_STEM}}}"
+mkdir -p "${ARTIFACT_DIR}"
+TELEMETRY_CSV="${ARTIFACT_DIR}/telemetry.csv"
+printf '%s\n' 'timestamp_utc,elapsed_seconds,gpu_index,gpu_utilization_percent,gpu_memory_used_mib,gpu_memory_total_mib,container_memory_usage' \
+  >"${TELEMETRY_CSV}"
 
 if [[ -n "${CHECKPOINT_PATH:-}" ]]; then
   CHECKPOINT_PATH="$(resolve_path "${CHECKPOINT_PATH}")"
@@ -158,12 +198,27 @@ if [[ "${BUILD_IMAGE}" != "0" ]]; then
     --build-arg CANDLE_FEATURES=cuda \
     --build-arg CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP}" \
     --build-arg CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT}" \
+    --build-arg PLUGIN_GIT_SHA="${PLUGIN_GIT_SHA}" \
     -t "${BACKEND_IMAGE}" \
     "${BACKEND_DIR}"
 else
   docker image inspect "${BACKEND_IMAGE}" >/dev/null 2>&1 \
     || die "Docker image not found or Docker is not accessible: ${BACKEND_IMAGE}"
 fi
+
+cat >"${ARTIFACT_DIR}/revisions.env" <<EOF
+plugin_sha=${PLUGIN_GIT_SHA}
+plugin_dirty=${PLUGIN_DIRTY}
+candle_sha=${CANDLE_SAM3_COMMIT}
+input_sha256=$(sha256sum "${INPUT_STACK}" | awk '{print $1}')
+checkpoint_sha256=$(sha256sum "${CHECKPOINT_PATH}" | awk '{print $1}')
+image_id=$(docker image inspect --format '{{.Id}}' "${BACKEND_IMAGE}")
+cuda_compute_cap=${CUDA_COMPUTE_CAP}
+cuda_device_ordinal=${CUDA_DEVICE_ORDINAL}
+gpu=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=name --format=csv,noheader 2>/dev/null || printf unavailable)
+driver_version=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=driver_version --format=csv,noheader 2>/dev/null || printf unavailable)
+cuda_runtime=$(docker run --rm --entrypoint /bin/sh "${BACKEND_IMAGE}" -c 'printf %s "${CUDA_VERSION:-unknown}"')
+EOF
 
 if [[ "${SKIP_GPU_CHECK:-0}" != "1" ]]; then
   log "Checking Docker GPU access with ${BACKEND_IMAGE}"
@@ -200,8 +255,13 @@ docker run -d \
   -v "${VOLUME_NAME}:/ouroboros-volume" \
   -e VOLUME_MOUNT_PATH=/ouroboros-volume \
   -e VOLUME_SERVER_URL=http://host.docker.internal:3001 \
+  -e CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL}" \
   --add-host host.docker.internal:host-gateway \
   "${BACKEND_IMAGE}" >/dev/null
+
+RUN_START_EPOCH="$(date +%s)"
+telemetry_loop "${RUN_START_EPOCH}" &
+TELEMETRY_PID=$!
 
 log "Waiting for backend on http://127.0.0.1:${HOST_PORT}"
 for _ in $(seq 1 60); do
@@ -252,16 +312,28 @@ while (( SECONDS < deadline )); do
       break
       ;;
     error)
-      docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+      capture_backend_log
+      tail -n "${LOG_TAIL_LINES}" "${ARTIFACT_DIR}/backend.log" >&2 || true
       die "Smoke job failed"
       ;;
   esac
 done
 
 [[ "${JOB_STATUS:-}" == "completed" ]] || {
-  docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+  capture_backend_log
+  tail -n "${LOG_TAIL_LINES}" "${ARTIFACT_DIR}/backend.log" >&2 || true
   die "Smoke job timed out after ${TIMEOUT_SECONDS}s"
 }
+
+capture_backend_log
+grep -F 'device=cuda' "${ARTIFACT_DIR}/backend.log" >/dev/null \
+  || die "Backend log does not prove CUDA model loading"
+grep -F "cuda_ordinal=${CUDA_DEVICE_ORDINAL}" "${ARTIFACT_DIR}/backend.log" >/dev/null \
+  || die "Backend log does not prove the requested CUDA ordinal"
+grep -F "plugin_sha=${PLUGIN_GIT_SHA}" "${ARTIFACT_DIR}/backend.log" >/dev/null \
+  || die "Backend log does not contain the expected plugin SHA"
+grep -F "candle_sha=${CANDLE_SAM3_COMMIT}" "${ARTIFACT_DIR}/backend.log" >/dev/null \
+  || die "Backend log does not contain the expected Candle SHA"
 
 log "Verifying output in Docker volume"
 docker run --rm \
@@ -301,6 +373,14 @@ source = geometry(sys.argv[1])
 output = geometry(sys.argv[2])
 if source != output:
     raise SystemExit(f"output geometry {output} does not match input {source}")
+with tifffile.TiffFile(sys.argv[2]) as tif:
+    for index, page in enumerate(tif.pages):
+        values = page.asarray()
+        if values.dtype != "uint8":
+            raise SystemExit(f"output page {index} has dtype {values.dtype}, expected uint8")
+        unique = set(int(value) for value in __import__("numpy").unique(values))
+        if not unique.issubset({0, 255}):
+            raise SystemExit(f"output page {index} is not binary: {sorted(unique)!r}")
 print(f"[smoke] output geometry verified: frames={output[0]}, height={output[1]}, width={output[2]}")
 PY
 else
@@ -313,4 +393,4 @@ if [[ -n "${OUTPUT_DIR:-}" ]]; then
   log "Copied output to ${OUTPUT_DIR}/${OUTPUT_NAME}"
 fi
 
-log "GPU biological-stack smoke completed successfully"
+log "GPU biological-stack smoke completed successfully; artifacts=${ARTIFACT_DIR}"

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+DEFAULT_CHECKPOINT_URL="https://huggingface.co/ChongCong/Medical-SAM3/resolve/main/checkpoint_3D.pt"
+DEFAULT_IMAGE="ouroboros-autoseg-backend:video-smoke-cuda"
+
+usage() {
+  cat <<'USAGE'
+Run the Medical SAM3 biological-stack video smoke on the CUDA backend.
+
+Usage:
+  INPUT_STACK=/path/to/straightened-stack.tif backend/scripts/biological_video_smoke_gpu.sh
+  backend/scripts/biological_video_smoke_gpu.sh /path/to/straightened-stack.tif
+
+Common options:
+  BUILD_IMAGE=0                 Use BACKEND_IMAGE instead of building this checkout.
+  BACKEND_IMAGE=name:tag         CUDA backend image to build/run.
+  CUDA_COMPUTE_CAP=75            CUDA compute capability used for the local image build.
+  CHECKPOINT_PATH=/path/model.pt Use an existing Medical SAM3 3D checkpoint.
+  CHECKPOINT_URL=https://...     Override the default checkpoint_3D.pt URL.
+  HOST_PORT=18788               Host port mapped to backend port 8686.
+  VOLUME_NAME=ouroboros-volume   Docker volume used as the plugin shared volume.
+  OUTPUT_NAME=mask_stack.tif     Output filename written under Segmentation/.
+  OUTPUT_DIR=/path/out           Also copy the output mask stack to this host dir.
+  KEEP_CONTAINER=1               Leave the backend container running after the script exits.
+
+The script builds/runs the CUDA Docker target with --gpus all, stages the input
+stack and Medical SAM3 3D checkpoint into the Docker volume, submits a
+VideoPredictor job, polls it to completion, and verifies that the mask stack was
+written. If Python tifffile is available, it also checks output geometry.
+USAGE
+}
+
+log() {
+  printf '[smoke] %s\n' "$*"
+}
+
+die() {
+  printf '[smoke] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+resolve_path() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+}
+
+json_value() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+value = payload
+for key in sys.argv[2].split("."):
+    value = value[key]
+print(value)
+PY
+}
+
+job_progress() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+steps = payload.get("steps", [])
+summary = ", ".join(
+    f"{step.get('name', '?')}={step.get('progress', '?')}%" for step in steps
+)
+print(summary or "no step progress")
+PY
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${VALIDATION_DIR:-}" && -d "${VALIDATION_DIR}" ]]; then
+    rm -rf "${VALIDATION_DIR}"
+  fi
+  if [[ "${KEEP_CONTAINER:-0}" != "1" ]]; then
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+  exit "${status}"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+INPUT_STACK="${INPUT_STACK:-${1:-}}"
+[[ -n "${INPUT_STACK}" ]] || {
+  usage
+  exit 2
+}
+
+require_command docker
+require_command curl
+require_command python3
+
+INPUT_STACK="$(resolve_path "${INPUT_STACK}")"
+[[ -f "${INPUT_STACK}" ]] || die "Input stack does not exist: ${INPUT_STACK}"
+
+BACKEND_IMAGE="${BACKEND_IMAGE:-${DEFAULT_IMAGE}}"
+BUILD_IMAGE="${BUILD_IMAGE:-1}"
+CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-75}"
+CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-770d20ca8db4f834ba4c89c845bca196fbfc97ea}"
+CHECKPOINT_URL="${CHECKPOINT_URL:-${DEFAULT_CHECKPOINT_URL}}"
+CHECKPOINT_CACHE="${CHECKPOINT_CACHE:-${XDG_CACHE_HOME:-${HOME}/.cache}/ouroboros-autoseg/medical_sam3_checkpoint_3D.pt}"
+HOST_PORT="${HOST_PORT:-18788}"
+VOLUME_NAME="${VOLUME_NAME:-ouroboros-volume}"
+CONTAINER_NAME="${CONTAINER_NAME:-ouroboros-autoseg-video-smoke}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-7200}"
+OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
+
+INPUT_DIR="$(dirname -- "${INPUT_STACK}")"
+INPUT_NAME="$(basename -- "${INPUT_STACK}")"
+INPUT_STEM="${INPUT_NAME%.*}"
+OUTPUT_NAME="${OUTPUT_NAME:-${INPUT_STEM}_video_smoke_mask.tif}"
+
+if [[ -n "${CHECKPOINT_PATH:-}" ]]; then
+  CHECKPOINT_PATH="$(resolve_path "${CHECKPOINT_PATH}")"
+  [[ -f "${CHECKPOINT_PATH}" ]] || die "Checkpoint does not exist: ${CHECKPOINT_PATH}"
+else
+  mkdir -p "$(dirname -- "${CHECKPOINT_CACHE}")"
+  if [[ ! -f "${CHECKPOINT_CACHE}" ]]; then
+    log "Downloading Medical SAM3 3D checkpoint"
+    curl_args=(-L --fail --continue-at - --output "${CHECKPOINT_CACHE}" "${CHECKPOINT_URL}")
+    if [[ -n "${HF_TOKEN:-}" ]]; then
+      curl_args=(-H "Authorization: Bearer ${HF_TOKEN}" "${curl_args[@]}")
+    fi
+    curl "${curl_args[@]}"
+  else
+    log "Using cached checkpoint: ${CHECKPOINT_CACHE}"
+  fi
+  CHECKPOINT_PATH="${CHECKPOINT_CACHE}"
+fi
+
+CHECKPOINT_DIR="$(dirname -- "${CHECKPOINT_PATH}")"
+CHECKPOINT_NAME="$(basename -- "${CHECKPOINT_PATH}")"
+
+if [[ "${BUILD_IMAGE}" != "0" ]]; then
+  log "Building CUDA backend image: ${BACKEND_IMAGE}"
+  docker build \
+    -f "${BACKEND_DIR}/Dockerfile" \
+    --target cuda-runtime \
+    --build-arg CANDLE_FEATURES=cuda \
+    --build-arg CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP}" \
+    --build-arg CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT}" \
+    -t "${BACKEND_IMAGE}" \
+    "${BACKEND_DIR}"
+else
+  docker image inspect "${BACKEND_IMAGE}" >/dev/null 2>&1 \
+    || die "Docker image not found or Docker is not accessible: ${BACKEND_IMAGE}"
+fi
+
+if [[ "${SKIP_GPU_CHECK:-0}" != "1" ]]; then
+  log "Checking Docker GPU access with ${BACKEND_IMAGE}"
+  docker run --rm --gpus all --entrypoint nvidia-smi "${BACKEND_IMAGE}" >/dev/null
+fi
+
+log "Staging input and checkpoint in Docker volume: ${VOLUME_NAME}"
+docker volume create "${VOLUME_NAME}" >/dev/null
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -v "${INPUT_DIR}:/input:ro" \
+  -v "${CHECKPOINT_DIR}:/checkpoint:ro" \
+  -e INPUT_NAME="${INPUT_NAME}" \
+  -e CHECKPOINT_NAME="${CHECKPOINT_NAME}" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu '
+    plugin_root=/volume/sam3-segmentation
+    mkdir -p "${plugin_root}/chkpts" "${plugin_root}/Segmentation"
+    rm -f "${plugin_root}/${INPUT_NAME}" "${plugin_root}/Segmentation/${OUTPUT_NAME}"
+    cp "/input/${INPUT_NAME}" "${plugin_root}/${INPUT_NAME}"
+    cp "/checkpoint/${CHECKPOINT_NAME}" "${plugin_root}/chkpts/medical_sam3.pt"
+  '
+
+trap cleanup EXIT
+
+log "Starting CUDA backend container: ${CONTAINER_NAME}"
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --gpus all \
+  -p "127.0.0.1:${HOST_PORT}:8686" \
+  -v "${VOLUME_NAME}:/ouroboros-volume" \
+  -e VOLUME_MOUNT_PATH=/ouroboros-volume \
+  -e VOLUME_SERVER_URL=http://host.docker.internal:3001 \
+  --add-host host.docker.internal:host-gateway \
+  "${BACKEND_IMAGE}" >/dev/null
+
+log "Waiting for backend on http://127.0.0.1:${HOST_PORT}"
+for _ in $(seq 1 60); do
+  if curl -fs "http://127.0.0.1:${HOST_PORT}/" >/dev/null 2>&1; then
+    break
+  fi
+  if ! docker inspect -f '{{.State.Running}}' "${CONTAINER_NAME}" 2>/dev/null | grep -qx true; then
+    docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+    die "Backend container exited before becoming ready"
+  fi
+  sleep 1
+done
+curl -fsS "http://127.0.0.1:${HOST_PORT}/" >/dev/null || die "Backend did not become ready"
+
+log "Submitting VideoPredictor smoke job"
+REQUEST_BODY="$(
+  python3 - "${INPUT_NAME}" "${OUTPUT_NAME}" "${OVERLAY_ANNOTATION_POINTS}" <<'PY'
+import json
+import sys
+
+input_name, output_name, overlay = sys.argv[1:4]
+print(json.dumps({
+    "file_path": f"/smoke/{input_name}",
+    "output_file": f"/smoke/{output_name}",
+    "model_type": "medical_sam3",
+    "predictor_type": "VideoPredictor",
+    "overlay_annotation_points": overlay.lower() == "true",
+}))
+PY
+)"
+SUBMIT_RESPONSE="$(
+  curl -fsS \
+    -X POST "http://127.0.0.1:${HOST_PORT}/process-stack" \
+    -H 'Content-Type: application/json' \
+    --data-binary "${REQUEST_BODY}"
+)"
+JOB_ID="$(json_value "${SUBMIT_RESPONSE}" "job_id")"
+log "Job accepted: ${JOB_ID}"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  sleep "${POLL_INTERVAL_SECONDS}"
+  STATUS_RESPONSE="$(curl -fsS "http://127.0.0.1:${HOST_PORT}/status/${JOB_ID}")"
+  JOB_STATUS="$(json_value "${STATUS_RESPONSE}" "status")"
+  log "status=${JOB_STATUS}; $(job_progress "${STATUS_RESPONSE}")"
+  case "${JOB_STATUS}" in
+    completed)
+      break
+      ;;
+    error)
+      docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+      die "Smoke job failed"
+      ;;
+  esac
+done
+
+[[ "${JOB_STATUS:-}" == "completed" ]] || {
+  docker logs --tail 200 "${CONTAINER_NAME}" >&2 || true
+  die "Smoke job timed out after ${TIMEOUT_SECONDS}s"
+}
+
+log "Verifying output in Docker volume"
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu 'test -s "/volume/sam3-segmentation/Segmentation/${OUTPUT_NAME}"'
+
+VALIDATION_DIR="$(mktemp -d)"
+docker run --rm \
+  --entrypoint /bin/sh \
+  -v "${VOLUME_NAME}:/volume" \
+  -v "${VALIDATION_DIR}:/out" \
+  -e OUTPUT_NAME="${OUTPUT_NAME}" \
+  "${BACKEND_IMAGE}" \
+  -ceu 'cp "/volume/sam3-segmentation/Segmentation/${OUTPUT_NAME}" "/out/${OUTPUT_NAME}"'
+
+if python3 -c 'import tifffile' >/dev/null 2>&1; then
+  python3 - "${INPUT_STACK}" "${VALIDATION_DIR}/${OUTPUT_NAME}" <<'PY'
+import sys
+import tifffile
+
+
+def geometry(path):
+    with tifffile.TiffFile(path) as tif:
+        if not tif.pages:
+            raise SystemExit(f"{path} has no TIFF pages")
+        pages = len(tif.pages)
+        shape = tif.pages[0].shape
+        if len(shape) < 2:
+            raise SystemExit(f"{path} first page has unsupported shape {shape!r}")
+        return pages, int(shape[0]), int(shape[1])
+
+
+source = geometry(sys.argv[1])
+output = geometry(sys.argv[2])
+if source != output:
+    raise SystemExit(f"output geometry {output} does not match input {source}")
+print(f"[smoke] output geometry verified: frames={output[0]}, height={output[1]}, width={output[2]}")
+PY
+else
+  log "Python tifffile is not installed; skipped output geometry validation"
+fi
+
+if [[ -n "${OUTPUT_DIR:-}" ]]; then
+  mkdir -p "${OUTPUT_DIR}"
+  cp "${VALIDATION_DIR}/${OUTPUT_NAME}" "${OUTPUT_DIR}/${OUTPUT_NAME}"
+  log "Copied output to ${OUTPUT_DIR}/${OUTPUT_NAME}"
+fi
+
+log "GPU biological-stack smoke completed successfully"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -65,7 +65,7 @@ const MODEL_CATALOG: &[ModelDescriptor] = &[
         checkpoint_file: "medical_sam3.pt",
         download_source: DownloadSource::HuggingFace {
             repo: "ChongCong/Medical-SAM3",
-            filename: "checkpoint_2D.pt",
+            filename: "checkpoint_3D.pt",
             requires_token: false,
         },
     },

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -65,7 +65,7 @@ const MODEL_CATALOG: &[ModelDescriptor] = &[
         checkpoint_file: "medical_sam3.pt",
         download_source: DownloadSource::HuggingFace {
             repo: "ChongCong/Medical-SAM3",
-            filename: "checkpoint.pt",
+            filename: "checkpoint_2D.pt",
             requires_token: false,
         },
     },

--- a/backend/src/imaging/output.rs
+++ b/backend/src/imaging/output.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use crate::{
     error::AppError,
-    imaging::tiff_io::{write_tiff_pages, WritableTiffPage},
+    imaging::{
+        annotations::{interpolated_point_for_frame, AnnotationPoint},
+        overlay::draw_annotation_star,
+        tiff_io::{write_tiff_pages, WritableTiffPage},
+    },
     inference::image::FrameMask,
 };
 
@@ -40,6 +44,29 @@ pub async fn write_mask_stack(target: &Path, masks: &[FrameMask]) -> Result<(), 
         .collect::<Result<Vec<_>, _>>()?;
 
     write_tiff_pages(target, &pages)
+}
+
+pub async fn write_annotation_overlay_stack(
+    target: &Path,
+    masks: &[FrameMask],
+    annotation_points: &[AnnotationPoint],
+    intensity: u8,
+) -> Result<(), AppError> {
+    let mut overlay_masks = masks.to_vec();
+    for (frame_index, mask) in overlay_masks.iter_mut().enumerate() {
+        if let Some(point) = interpolated_point_for_frame(annotation_points, frame_index) {
+            draw_annotation_star(
+                &mut mask.pixels,
+                mask.width,
+                mask.height,
+                point.x,
+                point.y,
+                intensity,
+            );
+        }
+    }
+
+    write_mask_stack(target, &overlay_masks).await
 }
 
 #[cfg(test)]

--- a/backend/src/imaging/output/tests.rs
+++ b/backend/src/imaging/output/tests.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-use super::write_mask_stack;
+use super::{write_annotation_overlay_stack, write_mask_stack};
 use crate::{
+    imaging::annotations::AnnotationPoint,
     imaging::tiff_io::{inspect_volume, read_volume_frames},
     inference::image::FrameMask,
 };
@@ -71,4 +72,39 @@ async fn write_mask_stack_rejects_inconsistent_geometry() {
         error.to_string(),
         "Mask stack frames must all share the same geometry"
     );
+}
+
+#[tokio::test]
+async fn write_annotation_overlay_stack_preserves_source_masks_and_marks_points() {
+    let root = unique_temp_dir();
+    let output_path = root.join("mask-overlay.tif");
+    let masks = vec![
+        FrameMask {
+            width: 5,
+            height: 5,
+            pixels: vec![0; 25],
+        },
+        FrameMask {
+            width: 5,
+            height: 5,
+            pixels: vec![0; 25],
+        },
+    ];
+    let annotations = vec![AnnotationPoint {
+        x: 2.0,
+        y: 2.0,
+        z: 0.0,
+    }];
+
+    write_annotation_overlay_stack(&output_path, &masks, &annotations, 127)
+        .await
+        .expect("write overlay stack");
+
+    assert!(masks[0].pixels.iter().all(|pixel| *pixel == 0));
+    let frames = read_volume_frames(&output_path)
+        .await
+        .expect("read overlay stack");
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0].pixels[2 + 2 * 5], 127);
+    assert_eq!(frames[1].pixels[2 + 2 * 5], 127);
 }

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -136,15 +136,7 @@ fn run_video_inference(
 
     let source =
         sam3::VideoSource::from_path(frames_dir).map_err(|e| AppError::internal(e.to_string()))?;
-    let session_options = sam3::VideoSessionOptions {
-        tokenizer_path: None,
-        memory_profile: sam3::VideoMemoryProfile::LowMemory,
-        offload_frames_to_cpu: false,
-        offload_state_to_cpu: false,
-        prefetch_ahead: 0,
-        prefetch_behind: 0,
-        max_feature_cache_entries: 2,
-    };
+    let session_options = low_memory_video_session_options();
 
     let model_ref = &*handle.image_model;
     let tracker_ref = &*handle.tracker;
@@ -210,4 +202,37 @@ fn run_video_inference(
         .iter()
         .map(|frame| video_frame_to_mask(&frame.objects, frame_width, frame_height))
         .collect()
+}
+
+fn low_memory_video_session_options() -> sam3::VideoSessionOptions {
+    sam3::VideoSessionOptions {
+        tokenizer_path: None,
+        memory_profile: sam3::VideoMemoryProfile::LowMemory,
+        offload_frames_to_cpu: false,
+        offload_state_to_cpu: false,
+        prefetch_ahead: 0,
+        prefetch_behind: 0,
+        max_feature_cache_entries: 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_session_options_use_low_memory_no_prefetch_profile() {
+        let options = low_memory_video_session_options();
+
+        assert!(matches!(
+            options.memory_profile,
+            sam3::VideoMemoryProfile::LowMemory
+        ));
+        assert!(!options.offload_frames_to_cpu);
+        assert!(!options.offload_state_to_cpu);
+        assert_eq!(options.prefetch_ahead, 0);
+        assert_eq!(options.prefetch_behind, 0);
+        assert_eq!(options.max_feature_cache_entries, 2);
+        assert!(options.tokenizer_path.is_none());
+    }
 }

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -3,6 +3,7 @@ use std::{path::Path, sync::Arc};
 use async_trait::async_trait;
 use candle_core::DType;
 use candle_transformers::models::sam3;
+use tracing::info;
 
 use crate::{
     app_state::Sam3ModelHandle,
@@ -34,6 +35,23 @@ pub fn load_sam3_handle(
     checkpoint_path: &std::path::Path,
     device: candle_core::Device,
 ) -> Result<Sam3ModelHandle, AppError> {
+    let device_kind = if device.is_cuda() { "cuda" } else { "cpu" };
+    let cuda_ordinal = device
+        .is_cuda()
+        .then(|| configured_cuda_ordinal().to_string())
+        .unwrap_or_else(|| "n/a".to_string());
+    let plugin_sha = option_env!("PLUGIN_GIT_SHA").unwrap_or("unknown");
+    let candle_sha = option_env!("CANDLE_SAM3_GIT_SHA").unwrap_or("unknown");
+    info!(
+        model = %model_name,
+        checkpoint = %checkpoint_path.display(),
+        device = %device_kind,
+        cuda_ordinal = %cuda_ordinal,
+        dtype = "f32",
+        plugin_sha = %plugin_sha,
+        candle_sha = %candle_sha,
+        "loading SAM3 model and tracker"
+    );
     let config = sam3::Config::default();
     let source = sam3::Sam3CheckpointSource::upstream_pth(checkpoint_path);
     let image_model =
@@ -48,6 +66,13 @@ pub fn load_sam3_handle(
         tracker: Arc::new(tracker),
         device,
     })
+}
+
+pub fn configured_cuda_ordinal() -> usize {
+    std::env::var("CUDA_DEVICE_ORDINAL")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0)
 }
 
 #[async_trait]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
+        .with_ansi(false)
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             EnvFilter::new("ouroboros_autoseg_plugin_backend=info,tower_http=info")
         }))

--- a/backend/src/services/checkpoints/tests.rs
+++ b/backend/src/services/checkpoints/tests.rs
@@ -165,7 +165,7 @@ fn medical_sam3_descriptor_uses_public_medical_checkpoint() {
             requires_token,
         } => {
             assert_eq!(repo, "ChongCong/Medical-SAM3");
-            assert_eq!(filename, "checkpoint.pt");
+            assert_eq!(filename, "checkpoint_2D.pt");
             assert!(!requires_token);
         }
         DownloadSource::PublicUrl(_) => panic!("medical_sam3 should use Hugging Face"),

--- a/backend/src/services/checkpoints/tests.rs
+++ b/backend/src/services/checkpoints/tests.rs
@@ -165,7 +165,7 @@ fn medical_sam3_descriptor_uses_public_medical_checkpoint() {
             requires_token,
         } => {
             assert_eq!(repo, "ChongCong/Medical-SAM3");
-            assert_eq!(filename, "checkpoint_2D.pt");
+            assert_eq!(filename, "checkpoint_3D.pt");
             assert!(!requires_token);
         }
         DownloadSource::PublicUrl(_) => panic!("medical_sam3 should use Hugging Face"),

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -189,10 +189,7 @@ async fn model_handle_for_request(
 fn inference_device() -> Result<candle_core::Device, AppError> {
     #[cfg(feature = "cuda")]
     {
-        let ordinal = std::env::var("CUDA_DEVICE_ORDINAL")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(0);
+        let ordinal = crate::inference::candle_sam3::configured_cuda_ordinal();
         candle_core::Device::new_cuda(ordinal).map_err(|error| {
             AppError::internal(format!(
                 "CUDA backend was requested but device {ordinal} is unavailable: {error}"

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::{
     app_state::{AppState, Sam3ModelHandle},
@@ -9,7 +12,7 @@ use crate::{
             annotation_samples_for_video, default_annotations, interpolated_point_for_frame,
             AnnotationPoint, VolumeShape,
         },
-        output::write_mask_stack,
+        output::{write_annotation_overlay_stack, write_mask_stack},
         preprocess::{stage_input_frames, PreparedFrame, PreparedFrameEncoding},
         tiff_io::{inspect_volume, read_volume_frames, VolumeInput},
     },
@@ -132,6 +135,15 @@ pub async fn run(state: &AppState, job_id: &str, request: &ProcessRequest) -> Re
         tokio::fs::create_dir_all(parent).await?;
     }
     write_mask_stack(&prepared.plan.volume_output, &masks).await?;
+    if request.overlay_annotation_points {
+        write_annotation_overlay_stack(
+            &annotation_overlay_path(&prepared.plan.volume_output),
+            &masks,
+            &prepared.annotation_points,
+            request.annotation_overlay_intensity,
+        )
+        .await?;
+    }
     tokio::fs::remove_dir_all(&prepared.plan.temp_volume_dir).await?;
     state.update_job_step(job_id, 3, 100).await;
 
@@ -200,9 +212,44 @@ async fn run_video_predictor(
     };
     let video_prompts =
         annotation_samples_for_video(&prepared.annotation_points, prepared.staged_frames.len());
-    segmenter
+    let masks = segmenter
         .segment_video(&prepared.plan.temp_volume_dir, &video_prompts)
-        .await
+        .await?;
+    validate_video_masks(&masks, prepared)?;
+    Ok(masks)
+}
+
+fn validate_video_masks(
+    masks: &[FrameMask],
+    prepared: &PreparedPipelineInput,
+) -> Result<(), AppError> {
+    let expected_frames = prepared.staged_frames.len();
+    if masks.len() != expected_frames {
+        return Err(AppError::upstream(format!(
+            "Video inference returned {} masks for {expected_frames} staged frames",
+            masks.len()
+        )));
+    }
+
+    let expected_width = prepared.volume.geometry.width;
+    let expected_height = prepared.volume.geometry.height;
+    for (index, mask) in masks.iter().enumerate() {
+        if mask.width != expected_width || mask.height != expected_height {
+            return Err(AppError::upstream(format!(
+                "Video inference mask {index} has geometry {}x{}, expected {expected_width}x{expected_height}",
+                mask.width, mask.height
+            )));
+        }
+        if mask.pixels.len() != expected_width * expected_height {
+            return Err(AppError::upstream(format!(
+                "Video inference mask {index} has {} pixels, expected {}",
+                mask.pixels.len(),
+                expected_width * expected_height
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn frame_name_width(frame_count: usize) -> usize {
@@ -217,6 +264,18 @@ fn stage_encoding(predictor_type: &str) -> Result<PreparedFrameEncoding, AppErro
             "Unknown predictor type: {other}"
         ))),
     }
+}
+
+fn annotation_overlay_path(output_path: &Path) -> PathBuf {
+    let extension = output_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("tif");
+    let stem = output_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("segmentation");
+    output_path.with_file_name(format!("{stem}_annotation_overlay.{extension}"))
 }
 
 #[cfg(test)]

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -177,12 +177,33 @@ async fn model_handle_for_request(
 
     let model_name = descriptor.model_name.to_string();
     let handle = tokio::task::spawn_blocking(move || {
-        load_sam3_handle(model_name, &checkpoint_path, candle_core::Device::Cpu)
+        let device = inference_device()?;
+        load_sam3_handle(model_name, &checkpoint_path, device)
     })
     .await
     .map_err(|e| AppError::internal(e.to_string()))??;
 
     Ok(state.set_sam3_handle(handle).await)
+}
+
+fn inference_device() -> Result<candle_core::Device, AppError> {
+    #[cfg(feature = "cuda")]
+    {
+        let ordinal = std::env::var("CUDA_DEVICE_ORDINAL")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        candle_core::Device::new_cuda(ordinal).map_err(|error| {
+            AppError::internal(format!(
+                "CUDA backend was requested but device {ordinal} is unavailable: {error}"
+            ))
+        })
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        Ok(candle_core::Device::Cpu)
+    }
 }
 
 async fn run_image_predictor(

--- a/backend/src/services/pipeline/tests.rs
+++ b/backend/src/services/pipeline/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::{plan, prepare, run};
+use super::{annotation_overlay_path, plan, prepare, run, validate_video_masks};
 use crate::{
     app_state::AppState,
     config::AppConfig,
@@ -9,6 +9,7 @@ use crate::{
         preprocess::PreparedFrameEncoding,
         tiff_io::{write_tiff_pages, WritableTiffPage},
     },
+    inference::image::FrameMask,
 };
 use uuid::Uuid;
 
@@ -152,6 +153,102 @@ async fn prepare_generates_default_annotations_for_missing_metadata() {
 }
 
 #[tokio::test]
+async fn validate_video_masks_accepts_expected_frame_count_and_geometry() {
+    let root = unique_temp_dir();
+    let state = test_state(root.clone());
+    let plugin_root = state.config().plugin_root();
+    std::fs::create_dir_all(&plugin_root).expect("create plugin root");
+    write_input_volume(&plugin_root.join("input-stack.tif"), None);
+    let prepared = prepare(&state, &sample_request("VideoPredictor"))
+        .await
+        .expect("prepare pipeline input");
+    let masks = vec![
+        FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![0; 8],
+        },
+        FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![255; 8],
+        },
+    ];
+
+    validate_video_masks(&masks, &prepared).expect("valid video masks");
+}
+
+#[tokio::test]
+async fn validate_video_masks_rejects_frame_count_geometry_and_pixels() {
+    let root = unique_temp_dir();
+    let state = test_state(root.clone());
+    let plugin_root = state.config().plugin_root();
+    std::fs::create_dir_all(&plugin_root).expect("create plugin root");
+    write_input_volume(&plugin_root.join("input-stack.tif"), None);
+    let prepared = prepare(&state, &sample_request("VideoPredictor"))
+        .await
+        .expect("prepare pipeline input");
+
+    let frame_count_error = validate_video_masks(
+        &[FrameMask {
+            width: 4,
+            height: 2,
+            pixels: vec![0; 8],
+        }],
+        &prepared,
+    )
+    .expect_err("frame count mismatch");
+    assert!(
+        frame_count_error
+            .to_string()
+            .contains("returned 1 masks for 2 staged frames"),
+        "{frame_count_error}"
+    );
+
+    let geometry_error = validate_video_masks(
+        &[
+            FrameMask {
+                width: 3,
+                height: 2,
+                pixels: vec![0; 6],
+            },
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 8],
+            },
+        ],
+        &prepared,
+    )
+    .expect_err("geometry mismatch");
+    assert!(
+        geometry_error.to_string().contains("expected 4x2"),
+        "{geometry_error}"
+    );
+
+    let pixel_error = validate_video_masks(
+        &[
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 7],
+            },
+            FrameMask {
+                width: 4,
+                height: 2,
+                pixels: vec![0; 8],
+            },
+        ],
+        &prepared,
+    )
+    .expect_err("pixel length mismatch");
+    assert!(
+        pixel_error.to_string().contains("has 7 pixels, expected 8"),
+        "{pixel_error}"
+    );
+}
+
+#[tokio::test]
 async fn run_requires_downloaded_sam3_checkpoint_before_staging() {
     let root = unique_temp_dir();
     let state = test_state(root.clone());
@@ -169,4 +266,12 @@ async fn run_requires_downloaded_sam3_checkpoint_before_staging() {
     );
     // Staging should not have happened since the model availability check is first.
     assert!(!plugin_root.join("input-stack_temp").exists());
+}
+
+#[test]
+fn annotation_overlay_path_keeps_primary_output_clean() {
+    assert_eq!(
+        annotation_overlay_path(Path::new("/tmp/Segmentation/segmented.tif")),
+        PathBuf::from("/tmp/Segmentation/segmented_annotation_overlay.tif")
+    );
 }

--- a/backend/src/services/pipeline/tests.rs
+++ b/backend/src/services/pipeline/tests.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::{annotation_overlay_path, plan, prepare, run, validate_video_masks};
+use super::{annotation_overlay_path, inference_device, plan, prepare, run, validate_video_masks};
 use crate::{
     app_state::AppState,
     config::AppConfig,
@@ -176,6 +176,12 @@ async fn validate_video_masks_accepts_expected_frame_count_and_geometry() {
     ];
 
     validate_video_masks(&masks, &prepared).expect("valid video masks");
+}
+
+#[cfg(not(feature = "cuda"))]
+#[test]
+fn cpu_build_selects_cpu_without_cuda_initialization() {
+    assert!(inference_device().expect("CPU device").is_cpu());
 }
 
 #[tokio::test]

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -126,7 +126,7 @@ class NetworkTests(unittest.TestCase):
 
         mocked_download.assert_called_once_with(
             repo_id="ChongCong/Medical-SAM3",
-            filename="checkpoint_2D.pt",
+            filename="checkpoint_3D.pt",
             token=None,
         )
         mocked_copy.assert_called_once_with("/tmp/cached-medical-sam3.pt", "/tmp/medical_sam3.pt")

--- a/backend/tests/util/test_network.py
+++ b/backend/tests/util/test_network.py
@@ -126,7 +126,7 @@ class NetworkTests(unittest.TestCase):
 
         mocked_download.assert_called_once_with(
             repo_id="ChongCong/Medical-SAM3",
-            filename="checkpoint.pt",
+            filename="checkpoint_2D.pt",
             token=None,
         )
         mocked_copy.assert_called_once_with("/tmp/cached-medical-sam3.pt", "/tmp/medical_sam3.pt")


### PR DESCRIPTION
## Summary

Restores a reproducible CUDA Medical-SAM3 baseline for the CANDLE-2 migration and hardens the biological-video smoke path.

This PR tracks https://github.com/den-sq/sam_parity/issues/34 and supersedes https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/pull/26.

The separate annotation-overlay output restores the corresponding smoke-harness behavior from https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/pull/26; it is emitted only when annotation overlaying is requested and does not alter the primary segmentation output.

## Changes

- updates the Medical-SAM3 checkpoint filename
- adds a GPU biological-video smoke script
- pins and documents the known-good Candle baseline
- emits machine-readable backend logs
- requires exact TIFF smoke validation
- hardens video-smoke readiness checks
- records the old-pin Medical control and artifact hashes

## Verification

- backend Rust suite: 57 passed
- Python network suite: 19 passed
- CPU image readiness passed
- CUDA image and Medical smoke passed against Candle `770d20ca8db4f834ba4c89c845bca196fbfc97ea`
- checkpoint SHA-256 begins `6e40bbaa`; fixture SHA-256 begins `48dd32e`; output SHA-256 begins `bf6d366d`
- `git diff --check`

## Stack

Base: `main`

The one-object continuity PR targets this branch.
