### PR TITLE
CANDLE-2.4: stream video outputs and close sessions

### DIFF
--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -17,6 +17,19 @@ later z-annotation reuses that ID, including multiple positive points grouped on
 one frame. A future multi-object annotation schema must provide explicit track
 IDs; independent rows must not implicitly allocate independent objects.
 
+Video propagation is consumed through Candle's streaming callback. Each yielded
+CUDA frame is thresholded and copied into its final CPU `FrameMask` slot before
+the callback returns; the plugin never retains a full `VideoOutput`. Frame
+indices are validated for direction, range, duplicates, and omissions, and the
+session is explicitly closed on both success and failure. Low-memory runs log
+`cached_output_frames` after propagation and require it to be zero.
+
+The final CPU result is intentionally still resident until TIFF writing
+completes. For 4,901 binary 200 x 200 pages, the mask pixel buffers account for
+about 187 MiB, plus vector metadata. The TIFF writer currently makes a
+comparable transient page-data copy, so full-stack host RSS acceptance must
+include both allocations.
+
 ## GPU Biological-Stack Smoke
 
 Use the smoke script for the checkpoint/dataset-dependent portion of AUTO-4. It

--- a/backend/docs/video_smoke.md
+++ b/backend/docs/video_smoke.md
@@ -72,3 +72,13 @@ page is `uint8` with binary values only.
 
 Use a separate run with `overlay_annotation_points` enabled when generating
 prompt-marker figure artifacts.
+
+## CANDLE-2 Streamed Control
+
+The 2026-07-18 cc7.5 control at plugin `03d94e6b17e8889b4db4a54a7e3c87744d2679d8`
+and Candle `770d20ca8db4f834ba4c89c845bca196fbfc97ea` ran the 16-page,
+200 x 200 Medical-SAM3 fixture in 92 seconds (0.174 fps), with 11,536 MiB peak
+VRAM and 327.0 MiB peak container RSS. The log recorded
+`cached_output_frames=0`. The streamed output SHA-256 was
+`bf6d366d33adc09053ba6da7065c88916d6780a133bb2779204f458af751c67e`,
+byte-identical to both collected old-pin controls.

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc};
 use async_trait::async_trait;
 use candle_core::DType;
 use candle_transformers::models::sam3;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     app_state::Sam3ModelHandle,
@@ -171,62 +171,192 @@ fn run_video_inference(
     let session_id = predictor
         .start_session(source, session_options)
         .map_err(|e| AppError::internal(e.to_string()))?;
-    predictor
-        .reset_session(&session_id)
-        .map_err(|e| AppError::internal(e.to_string()))?;
+    with_deterministic_session_close(
+        &mut predictor,
+        |predictor| {
+            predictor
+                .reset_session(&session_id)
+                .map_err(|e| AppError::internal(e.to_string()))?;
 
-    let w = frame_width as f32;
-    let h = frame_height as f32;
-    register_single_trajectory_prompts(prompts, |vfp, obj_id| {
-        let session_prompt = sam3::SessionPrompt {
-            text: None,
-            points: if vfp.points.is_empty() {
-                None
-            } else {
-                Some(
-                    vfp.points
-                        .iter()
-                        .map(|p| ((p.x / w).clamp(0.0, 1.0), (p.y / h).clamp(0.0, 1.0)))
-                        .collect(),
+            let w = frame_width as f32;
+            let h = frame_height as f32;
+            register_single_trajectory_prompts(prompts, |vfp, obj_id| {
+                let session_prompt = sam3::SessionPrompt {
+                    text: None,
+                    points: if vfp.points.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            vfp.points
+                                .iter()
+                                .map(|p| ((p.x / w).clamp(0.0, 1.0), (p.y / h).clamp(0.0, 1.0)))
+                                .collect(),
+                        )
+                    },
+                    point_labels: if vfp.points.is_empty() {
+                        None
+                    } else {
+                        Some(vec![1u32; vfp.points.len()])
+                    },
+                    boxes: None,
+                    box_labels: None,
+                };
+                predictor
+                    .add_prompt(
+                        &session_id,
+                        vfp.frame_index,
+                        session_prompt,
+                        obj_id,
+                        true,
+                        false,
+                    )
+                    .map_err(|e| AppError::internal(e.to_string()))
+            })?;
+
+            let frame_count = predictor
+                .session_frame_count(&session_id)
+                .map_err(|e| AppError::internal(e.to_string()))?;
+            let mut masks = VideoMaskCollector::new(frame_count)?;
+            predictor
+                .propagate_in_video_stream(
+                    &session_id,
+                    sam3::PropagationOptions {
+                        direction: sam3::PropagationDirection::Forward,
+                        start_frame_idx: None,
+                        max_frame_num_to_track: None,
+                        output_prob_threshold: Some(0.5),
+                    },
+                    |frame| {
+                        let mask = video_frame_to_mask(&frame.objects, frame_width, frame_height)
+                            .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
+                        masks
+                            .push_forward(frame.frame_idx, mask)
+                            .map_err(|e| candle_core::Error::Msg(e.to_string()))
+                    },
                 )
-            },
-            point_labels: if vfp.points.is_empty() {
-                None
-            } else {
-                Some(vec![1u32; vfp.points.len()])
-            },
-            boxes: None,
-            box_labels: None,
-        };
-        predictor
-            .add_prompt(
-                &session_id,
-                vfp.frame_index,
-                session_prompt,
-                obj_id,
-                true,
-                false,
-            )
-            .map_err(|e| AppError::internal(e.to_string()))
-    })?;
+                .map_err(|e| AppError::internal(e.to_string()))?;
+            let cache_stats = predictor
+                .session_cache_stats(&session_id)
+                .map_err(|e| AppError::internal(e.to_string()))?;
+            info!(
+                cached_output_frames = cache_stats.cached_output_frames,
+                "completed streamed SAM3 video propagation"
+            );
+            if cache_stats.cached_output_frames != 0 {
+                return Err(AppError::upstream(format!(
+                    "Low-memory video stream retained {} cached output frames after propagation",
+                    cache_stats.cached_output_frames
+                )));
+            }
+            masks.finish()
+        },
+        |predictor| {
+            predictor
+                .close_session(&session_id)
+                .map_err(|e| AppError::internal(e.to_string()))
+        },
+    )
+}
 
-    let output = predictor
-        .propagate_in_video(
-            &session_id,
-            sam3::PropagationOptions {
-                direction: sam3::PropagationDirection::Forward,
-                start_frame_idx: None,
-                max_frame_num_to_track: None,
-                output_prob_threshold: Some(0.5),
-            },
-        )
-        .map_err(|e| AppError::internal(e.to_string()))?;
+struct VideoMaskCollector {
+    masks: Vec<Option<FrameMask>>,
+    last_frame_idx: Option<usize>,
+}
 
-    output
-        .frames
-        .iter()
-        .map(|frame| video_frame_to_mask(&frame.objects, frame_width, frame_height))
-        .collect()
+impl VideoMaskCollector {
+    fn new(frame_count: usize) -> Result<Self, AppError> {
+        if frame_count == 0 {
+            return Err(AppError::bad_request(
+                "Cannot collect streamed masks for an empty video",
+            ));
+        }
+        Ok(Self {
+            masks: vec![None; frame_count],
+            last_frame_idx: None,
+        })
+    }
+
+    fn push_forward(&mut self, frame_idx: usize, mask: FrameMask) -> Result<(), AppError> {
+        if frame_idx >= self.masks.len() {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted out-of-range frame {frame_idx} for {} frames",
+                self.masks.len()
+            )));
+        }
+        if self.masks[frame_idx].is_some() {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted duplicate frame {frame_idx}"
+            )));
+        }
+        if self.last_frame_idx.is_some_and(|last| frame_idx <= last) {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted invalid forward order: frame {frame_idx} after {}",
+                self.last_frame_idx.unwrap_or_default()
+            )));
+        }
+
+        self.masks[frame_idx] = Some(mask);
+        self.last_frame_idx = Some(frame_idx);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn push_backward(&mut self, frame_idx: usize, mask: FrameMask) -> Result<(), AppError> {
+        if frame_idx >= self.masks.len() {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted out-of-range frame {frame_idx} for {} frames",
+                self.masks.len()
+            )));
+        }
+        if self.masks[frame_idx].is_some() {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted duplicate frame {frame_idx}"
+            )));
+        }
+        if self.last_frame_idx.is_some_and(|last| frame_idx >= last) {
+            return Err(AppError::upstream(format!(
+                "Video stream emitted invalid backward order: frame {frame_idx} after {}",
+                self.last_frame_idx.unwrap_or_default()
+            )));
+        }
+
+        self.masks[frame_idx] = Some(mask);
+        self.last_frame_idx = Some(frame_idx);
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Vec<FrameMask>, AppError> {
+        let missing = self
+            .masks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, mask)| mask.is_none().then_some(index))
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return Err(AppError::upstream(format!(
+                "Video stream omitted frame indices {missing:?}"
+            )));
+        }
+        Ok(self.masks.into_iter().flatten().collect())
+    }
+}
+
+fn with_deterministic_session_close<P, T>(
+    predictor: &mut P,
+    operation: impl FnOnce(&mut P) -> Result<T, AppError>,
+    close: impl FnOnce(&mut P) -> Result<(), AppError>,
+) -> Result<T, AppError> {
+    let operation_result = operation(predictor);
+    let close_result = close(predictor);
+    match (operation_result, close_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(close_error)) => Err(close_error),
+        (Err(operation_error), Ok(())) => Err(operation_error),
+        (Err(operation_error), Err(close_error)) => {
+            warn!(%close_error, "failed to close video session after inference error");
+            Err(operation_error)
+        }
+    }
 }
 
 fn register_single_trajectory_prompts(
@@ -270,6 +400,14 @@ mod tests {
     use super::*;
     use crate::inference::image::PositivePointPrompt;
 
+    fn test_mask(value: u8) -> FrameMask {
+        FrameMask {
+            width: 1,
+            height: 1,
+            pixels: vec![value],
+        }
+    }
+
     #[test]
     fn video_session_options_use_low_memory_no_prefetch_profile() {
         let options = low_memory_video_session_options();
@@ -284,6 +422,122 @@ mod tests {
         assert_eq!(options.prefetch_behind, 0);
         assert_eq!(options.max_feature_cache_entries, 2);
         assert!(options.tokenizer_path.is_none());
+    }
+
+    #[test]
+    fn video_stream_matches_collected_masks_for_forward_and_backward_callbacks() {
+        let mut forward = VideoMaskCollector::new(3).expect("collector");
+        for (frame_idx, value) in [(0, 10), (1, 20), (2, 30)] {
+            forward
+                .push_forward(frame_idx, test_mask(value))
+                .expect("forward callback");
+        }
+        let forward = forward.finish().expect("complete forward stream");
+        assert_eq!(
+            forward
+                .iter()
+                .map(|mask| mask.pixels[0])
+                .collect::<Vec<_>>(),
+            vec![10, 20, 30]
+        );
+
+        let mut backward = VideoMaskCollector::new(3).expect("collector");
+        // These callbacks may arrive in a burst, but retain directional order.
+        for (frame_idx, value) in [(2, 30), (1, 20), (0, 10)] {
+            backward
+                .push_backward(frame_idx, test_mask(value))
+                .expect("backward callback");
+        }
+        let backward = backward.finish().expect("complete backward stream");
+        assert_eq!(
+            backward
+                .iter()
+                .map(|mask| mask.pixels[0])
+                .collect::<Vec<_>>(),
+            vec![10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn video_output_validation_rejects_missing_duplicate_out_of_range_and_invalid_order() {
+        let mut missing = VideoMaskCollector::new(3).expect("collector");
+        missing.push_forward(0, test_mask(0)).expect("frame 0");
+        missing.push_forward(2, test_mask(2)).expect("frame 2");
+        assert!(missing
+            .finish()
+            .expect_err("missing frame must fail")
+            .to_string()
+            .contains("[1]"));
+
+        let mut duplicate = VideoMaskCollector::new(2).expect("collector");
+        duplicate.push_forward(0, test_mask(0)).expect("frame 0");
+        assert!(duplicate
+            .push_forward(0, test_mask(0))
+            .expect_err("duplicate frame must fail")
+            .to_string()
+            .contains("duplicate frame 0"));
+
+        let mut out_of_range = VideoMaskCollector::new(2).expect("collector");
+        assert!(out_of_range
+            .push_forward(2, test_mask(2))
+            .expect_err("out-of-range frame must fail")
+            .to_string()
+            .contains("out-of-range frame 2"));
+
+        let mut invalid_order = VideoMaskCollector::new(3).expect("collector");
+        invalid_order
+            .push_forward(1, test_mask(1))
+            .expect("frame 1");
+        assert!(invalid_order
+            .push_forward(0, test_mask(0))
+            .expect_err("reverse callback in forward stream must fail")
+            .to_string()
+            .contains("invalid forward order"));
+    }
+
+    #[test]
+    fn video_stream_closes_session_after_success_and_conversion_failure() {
+        #[derive(Default)]
+        struct FakePredictor {
+            operated: bool,
+            closed: bool,
+        }
+
+        let mut success = FakePredictor::default();
+        let value = with_deterministic_session_close(
+            &mut success,
+            |predictor| {
+                predictor.operated = true;
+                Ok(42)
+            },
+            |predictor| {
+                predictor.closed = true;
+                Ok(())
+            },
+        )
+        .expect("successful operation and close");
+        assert_eq!(value, 42);
+        assert!(success.operated);
+        assert!(success.closed);
+
+        let mut failure = FakePredictor::default();
+        let error = with_deterministic_session_close(
+            &mut failure,
+            |predictor| {
+                predictor.operated = true;
+                Err::<(), _>(AppError::internal("injected callback conversion failure"))
+            },
+            |predictor| {
+                predictor.closed = true;
+                Ok(())
+            },
+        )
+        .expect_err("conversion failure must propagate");
+        assert!(error
+            .to_string()
+            .contains("injected callback conversion failure"));
+        assert!(failure.operated);
+        assert!(failure.closed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Streams video masks as they are produced and explicitly closes backend sessions, avoiding full-output accumulation.

This stacked PR tracks https://github.com/den-sq/sam_parity/issues/31.

## Changes

- consumes video-mask output incrementally
- validates each streamed output
- closes inference sessions on success and failure paths
- records the streamed CUDA control

## Verification

- backend Rust suite on the merged Candle 0.11 base: 63 passed
- Python network suite on the merged Candle 0.11 base: 19 passed
- annotation contract tests passed
- targeted streaming, output-validation, and close-on-success/failure tests passed
- 16-frame Medical SAM3 CUDA streamed smoke passed against merged Candle `c11c900354467d50985a78a1895945199c9f4ecb` from https://github.com/den-sq/candle_sam3/pull/3
- 320 seconds, peak VRAM 9,169 MiB, `cached_output_frames=0`
- output is a binary `uint8` TIFF with shape `16 x 200 x 200`
- output SHA-256 `3a6bacb71268826c03b97dc25210155f0f2f6135c171ffebaa77203daeb73913`, matching the post-upgrade candidate control
- image `sha256:fc1f672952daff1ee47985e13d4db900d3aa514e67df23a983c6429ae9951185`
- full 4,901-frame writer-path allocation test at `200 x 200`: 362,496 KiB (354 MiB) peak RSS, including all `FrameMask` storage, the writer's page/pixel clones, and TIFF output
- `git diff --check`

The full-stack writer measurement closes the remaining integration-memory question: the output writer has a bounded approximately 2x mask-buffer peak, not an additional multi-gigabyte accumulation. The separate lazy caller-owned frame-source work remains scoped to https://github.com/den-sq/sam_parity/issues/41 and does not block this streaming/session-close change.

## Stack

Base: `codex/candle-2-03-one-object`

The merged-Candle revalidation gate is complete. The streaming/close smoke will be rerun after the separate lazy frame-source work in https://github.com/den-sq/sam_parity/issues/41 lands, as required by that issue's acceptance criteria.
