### PR TITLE
CANDLE-2.6: add explicit low-memory video profiles

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.11.0"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -249,6 +249,7 @@ dependencies = [
  "float8",
  "gemm 0.19.0",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -256,37 +257,38 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "thiserror 2.0.18",
  "tokenizers",
  "yoke 0.8.3",
+ "zerocopy",
  "zip",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.9.2"
+version = "0.11.0"
 dependencies = [
  "cudaforge",
 ]
 
 [[package]]
 name = "candle-nn"
-version = "0.9.2"
+version = "0.11.0"
 dependencies = [
  "candle-core",
  "half",
  "libc",
  "num-traits",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-transformers"
-version = "0.9.2"
+version = "0.11.0"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -305,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.9.2"
+version = "0.11.0"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -624,9 +626,9 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata 0.4.14",
@@ -2036,13 +2038,15 @@ dependencies = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.0",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3151,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "indexmap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,9 +21,9 @@ cudnn = [
 
 [dependencies]
 async-trait = "=0.1.77"
-candle-core = { path = "../../candle_sam3_main/candle-core", package = "candle-core", version = "0.9.2" }
-candle-nn = { path = "../../candle_sam3_main/candle-nn", version = "0.9.2" }
-candle-transformers = { path = "../../candle_sam3_main/candle-transformers", version = "0.9.2" }
+candle-core = { path = "../../candle_sam3_main/candle-core", package = "candle-core", version = "0.11.0" }
+candle-nn = { path = "../../candle_sam3_main/candle-nn", version = "0.11.0" }
+candle-transformers = { path = "../../candle_sam3_main/candle-transformers", version = "0.11.0" }
 axum = { version = "=0.6.20", features = ["json", "macros"] }
 futures-util = "=0.3.31"
 image = { version = "=0.25.10", default-features = false, features = ["jpeg", "tiff"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 
 # Clone candle_sam3 at the pinned commit used during development.
-ARG CANDLE_SAM3_COMMIT=770d20ca8db4f834ba4c89c845bca196fbfc97ea
+ARG CANDLE_SAM3_COMMIT=5b923247529646f3e1f59fefa60b3d6cca137b7b
 ARG PLUGIN_GIT_SHA=unknown
 ENV CANDLE_SAM3_GIT_SHA=${CANDLE_SAM3_COMMIT}
 ENV PLUGIN_GIT_SHA=${PLUGIN_GIT_SHA}
@@ -53,7 +53,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 WORKDIR /build
 
-ARG CANDLE_SAM3_COMMIT=770d20ca8db4f834ba4c89c845bca196fbfc97ea
+ARG CANDLE_SAM3_COMMIT=5b923247529646f3e1f59fefa60b3d6cca137b7b
 ARG PLUGIN_GIT_SHA=unknown
 ENV CANDLE_SAM3_GIT_SHA=${CANDLE_SAM3_COMMIT}
 ENV PLUGIN_GIT_SHA=${PLUGIN_GIT_SHA}

--- a/backend/scripts/benchmark_low_memory_profiles_gpu.sh
+++ b/backend/scripts/benchmark_low_memory_profiles_gpu.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE_SCRIPT="${SCRIPT_DIR}/biological_video_smoke_gpu.sh"
+
+usage() {
+  cat <<'USAGE'
+Benchmark the explicit CANDLE-2 low-memory video state profiles.
+
+Usage:
+  INPUT_STACK=/path/input.tif CHECKPOINT_PATH=/path/checkpoint.pt \
+    backend/scripts/benchmark_low_memory_profiles_gpu.sh
+  INPUT_STACK=/path/input.tif REUSE_STAGED_CHECKPOINT=1 \
+    VOLUME_NAME=existing-volume backend/scripts/benchmark_low_memory_profiles_gpu.sh
+
+Controls:
+  FRAME_COUNTS="32 128 512"            Workloads to generate from the source stack.
+  STATE_PROFILES="gpu-resident cpu-offload"  Variant B followed by variant C.
+  FEATURE_CACHE_ENTRIES="1 2"          Feature-cache capacities to compare.
+  RESULTS_DIR=/path/results             CSV, logs, outputs, and exact revisions.
+  BACKEND_IMAGE=name:tag                Image reused for all matrix entries.
+  BUILD_IMAGE=1                         Build once before the first matrix entry.
+  VOLUME_NAME=candle2-low-memory-profile Shared checkpoint/output Docker volume.
+  REUSE_STAGED_CHECKPOINT=1             Avoid another private checkpoint copy.
+  AVAILABLE_DISK_GIB_MIN=30             Refuse to start below this host-space floor.
+
+The source TIFF pages are repeated deterministically. Its JSON image description,
+including annotation_points, is preserved while the declared stack shape is
+updated. This harness intentionally keeps the legacy transformer-owned frame
+adapter as the control; https://github.com/den-sq/sam_parity/issues/41 is not
+selected into this matrix.
+USAGE
+}
+
+[[ "${1:-}" != "-h" && "${1:-}" != "--help" ]] || {
+  usage
+  exit 0
+}
+
+INPUT_STACK="${INPUT_STACK:-${1:-}}"
+CHECKPOINT_PATH="${CHECKPOINT_PATH:-}"
+[[ -f "${INPUT_STACK}" ]] || { usage >&2; exit 2; }
+REUSE_STAGED_CHECKPOINT="${REUSE_STAGED_CHECKPOINT:-0}"
+if [[ "${REUSE_STAGED_CHECKPOINT}" != "1" && ! -f "${CHECKPOINT_PATH}" ]]; then
+  usage >&2
+  exit 2
+fi
+
+FRAME_COUNTS="${FRAME_COUNTS:-32 128 512}"
+STATE_PROFILES="${STATE_PROFILES:-gpu-resident cpu-offload}"
+FEATURE_CACHE_ENTRIES="${FEATURE_CACHE_ENTRIES:-1 2}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/candle2-low-memory-profile}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-ouroboros-autoseg-backend:candle2-low-memory-cuda}"
+VOLUME_NAME="${VOLUME_NAME:-candle2-low-memory-profile}"
+BUILD_IMAGE="${BUILD_IMAGE:-1}"
+AVAILABLE_DISK_GIB_MIN="${AVAILABLE_DISK_GIB_MIN:-30}"
+TIFF_PYTHON="${TIFF_PYTHON:-python3}"
+mkdir -p "${RESULTS_DIR}/inputs" "${RESULTS_DIR}/runs"
+
+available_kib=$(df --output=avail "${RESULTS_DIR}" | tail -1 | tr -d ' ')
+minimum_kib=$((AVAILABLE_DISK_GIB_MIN * 1024 * 1024))
+if (( available_kib < minimum_kib )); then
+  printf 'Refusing benchmark: %s GiB free is below the %s GiB floor.\n' \
+    "$((available_kib / 1024 / 1024))" "${AVAILABLE_DISK_GIB_MIN}" >&2
+  exit 1
+fi
+
+printf '%s\n' \
+  'frame_count,state_profile,feature_cache_entries,status,elapsed_seconds,peak_gpu_memory_mib,peak_gpu_utilization_percent,output_sha256' \
+  >"${RESULTS_DIR}/summary.csv"
+
+run_index=0
+for frame_count in ${FRAME_COUNTS}; do
+  generated="${RESULTS_DIR}/inputs/fixture_${frame_count}.tif"
+  "${TIFF_PYTHON}" - "${INPUT_STACK}" "${generated}" "${frame_count}" <<'PY'
+import json
+import sys
+import numpy as np
+import tifffile
+
+source, output, frame_count = sys.argv[1], sys.argv[2], int(sys.argv[3])
+with tifffile.TiffFile(source) as tif:
+    frames = tif.asarray()
+    description = json.loads(tif.pages[0].description or "{}")
+if frames.shape[0] == 0:
+    raise SystemExit("source TIFF has no frames")
+indices = np.arange(frame_count) % frames.shape[0]
+generated = frames[indices]
+shape = list(description.get("shape", list(generated.shape)))
+shape[0] = frame_count
+description["shape"] = shape
+tifffile.imwrite(output, generated, description=json.dumps(description, separators=(",", ":")))
+PY
+
+  for state_profile in ${STATE_PROFILES}; do
+    for feature_cache_entries in ${FEATURE_CACHE_ENTRIES}; do
+      run_index=$((run_index + 1))
+      run_name="f${frame_count}-${state_profile}-cache${feature_cache_entries}"
+      run_dir="${RESULTS_DIR}/runs/${run_name}"
+      mkdir -p "${run_dir}"
+      status=passed
+      if ! INPUT_STACK="${generated}" \
+        CHECKPOINT_PATH="${CHECKPOINT_PATH}" \
+        BUILD_IMAGE="${BUILD_IMAGE}" \
+        BACKEND_IMAGE="${BACKEND_IMAGE}" \
+        VOLUME_NAME="${VOLUME_NAME}" \
+        REUSE_STAGED_CHECKPOINT="${REUSE_STAGED_CHECKPOINT}" \
+        CONTAINER_NAME="candle2-low-memory-${run_name}" \
+        HOST_PORT="$((18800 + run_index))" \
+        OUTPUT_NAME="${run_name}.tif" \
+        ARTIFACT_DIR="${run_dir}" \
+        OUTPUT_DIR="${run_dir}" \
+        SAM3_VIDEO_STATE_PROFILE="${state_profile}" \
+        SAM3_VIDEO_FEATURE_CACHE_ENTRIES="${feature_cache_entries}" \
+        "${SMOKE_SCRIPT}"; then
+        status=failed
+      fi
+      BUILD_IMAGE=0
+      elapsed=$(awk -F, 'END {print $2+0}' "${run_dir}/telemetry.csv" 2>/dev/null || printf 0)
+      peak_memory=$(awk -F, 'NR>1 {gsub(/ /,"",$5); if ($5+0>m) m=$5+0} END {print m+0}' "${run_dir}/telemetry.csv" 2>/dev/null || printf 0)
+      peak_util=$(awk -F, 'NR>1 {gsub(/ /,"",$4); if ($4+0>m) m=$4+0} END {print m+0}' "${run_dir}/telemetry.csv" 2>/dev/null || printf 0)
+      output_sha=$(sha256sum "${run_dir}/${run_name}.tif" 2>/dev/null | awk '{print $1}' || true)
+      printf '%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "${frame_count}" "${state_profile}" "${feature_cache_entries}" "${status}" \
+        "${elapsed}" "${peak_memory}" "${peak_util}" "${output_sha}" \
+        >>"${RESULTS_DIR}/summary.csv"
+      [[ "${status}" == passed ]] || exit 1
+    done
+  done
+done

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -21,12 +21,15 @@ Common options:
   CUDA_COMPUTE_CAP=75            CUDA compute capability used for the local image build.
   CHECKPOINT_PATH=/path/model.pt Use an existing Medical SAM3 3D checkpoint.
   CHECKPOINT_URL=https://...     Override the default checkpoint_3D.pt URL.
+  REUSE_STAGED_CHECKPOINT=1     Reuse medical_sam3.pt already in VOLUME_NAME.
   HOST_PORT=18788               Host port mapped to backend port 8686.
   VOLUME_NAME=ouroboros-volume   Docker volume used as the plugin shared volume.
   OUTPUT_NAME=mask_stack.tif     Output filename written under Segmentation/.
   OUTPUT_DIR=/path/out           Also copy the output mask stack to this host dir.
   ARTIFACT_DIR=/path/artifacts   Store revisions, telemetry, and bounded backend logs here.
   TELEMETRY_INTERVAL_SECONDS=1  Sampling interval for GPU, RSS, and elapsed-time CSV rows.
+  SAM3_VIDEO_STATE_PROFILE=cpu-offload  State profile: gpu-resident (B) or cpu-offload (C).
+  SAM3_VIDEO_FEATURE_CACHE_ENTRIES=1    Feature-cache capacity benchmark control: 1 or 2.
   TIFF_VALIDATOR_PYTHON=python3  Python interpreter with tifffile and numpy installed.
   KEEP_CONTAINER=1               Leave the backend container running after the script exits.
 
@@ -145,7 +148,7 @@ INPUT_STACK="$(resolve_path "${INPUT_STACK}")"
 BACKEND_IMAGE="${BACKEND_IMAGE:-${DEFAULT_IMAGE}}"
 BUILD_IMAGE="${BUILD_IMAGE:-1}"
 CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-75}"
-CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-770d20ca8db4f834ba4c89c845bca196fbfc97ea}"
+CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-5b923247529646f3e1f59fefa60b3d6cca137b7b}"
 PLUGIN_GIT_SHA="${PLUGIN_GIT_SHA:-$(git -C "${BACKEND_DIR}/.." rev-parse HEAD)}"
 PLUGIN_DIRTY="$(git -C "${BACKEND_DIR}/.." status --porcelain | awk 'NF { found=1 } END { print found ? "true" : "false" }')"
 CHECKPOINT_URL="${CHECKPOINT_URL:-${DEFAULT_CHECKPOINT_URL}}"
@@ -159,6 +162,9 @@ TELEMETRY_INTERVAL_SECONDS="${TELEMETRY_INTERVAL_SECONDS:-1}"
 CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL:-0}"
 LOG_TAIL_LINES="${LOG_TAIL_LINES:-500}"
 OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
+REUSE_STAGED_CHECKPOINT="${REUSE_STAGED_CHECKPOINT:-0}"
+SAM3_VIDEO_STATE_PROFILE="${SAM3_VIDEO_STATE_PROFILE:-cpu-offload}"
+SAM3_VIDEO_FEATURE_CACHE_ENTRIES="${SAM3_VIDEO_FEATURE_CACHE_ENTRIES:-1}"
 if [[ -x "${BACKEND_DIR}/.venv/bin/python" ]]; then
   DEFAULT_TIFF_VALIDATOR_PYTHON="${BACKEND_DIR}/.venv/bin/python"
 else
@@ -176,7 +182,10 @@ TELEMETRY_CSV="${ARTIFACT_DIR}/telemetry.csv"
 printf '%s\n' 'timestamp_utc,elapsed_seconds,gpu_index,gpu_utilization_percent,gpu_memory_used_mib,gpu_memory_total_mib,container_memory_usage' \
   >"${TELEMETRY_CSV}"
 
-if [[ -n "${CHECKPOINT_PATH:-}" ]]; then
+if [[ "${REUSE_STAGED_CHECKPOINT}" == "1" ]]; then
+  CHECKPOINT_PATH=""
+  CHECKPOINT_NAME="medical_sam3.pt"
+elif [[ -n "${CHECKPOINT_PATH:-}" ]]; then
   CHECKPOINT_PATH="$(resolve_path "${CHECKPOINT_PATH}")"
   [[ -f "${CHECKPOINT_PATH}" ]] || die "Checkpoint does not exist: ${CHECKPOINT_PATH}"
 else
@@ -194,8 +203,10 @@ else
   CHECKPOINT_PATH="${CHECKPOINT_CACHE}"
 fi
 
-CHECKPOINT_DIR="$(dirname -- "${CHECKPOINT_PATH}")"
-CHECKPOINT_NAME="$(basename -- "${CHECKPOINT_PATH}")"
+if [[ "${REUSE_STAGED_CHECKPOINT}" != "1" ]]; then
+  CHECKPOINT_DIR="$(dirname -- "${CHECKPOINT_PATH}")"
+  CHECKPOINT_NAME="$(basename -- "${CHECKPOINT_PATH}")"
+fi
 
 if [[ "${BUILD_IMAGE}" != "0" ]]; then
   log "Building CUDA backend image: ${BACKEND_IMAGE}"
@@ -213,15 +224,31 @@ else
     || die "Docker image not found or Docker is not accessible: ${BACKEND_IMAGE}"
 fi
 
+docker volume create "${VOLUME_NAME}" >/dev/null
+if [[ "${REUSE_STAGED_CHECKPOINT}" == "1" ]]; then
+  CHECKPOINT_SHA256="$(
+    docker run --rm \
+      --entrypoint /bin/sh \
+      -v "${VOLUME_NAME}:/volume" \
+      "${BACKEND_IMAGE}" \
+      -ceu 'sha256sum /volume/sam3-segmentation/chkpts/medical_sam3.pt' \
+      | awk '{print $1}'
+  )"
+else
+  CHECKPOINT_SHA256="$(sha256sum "${CHECKPOINT_PATH}" | awk '{print $1}')"
+fi
+
 cat >"${ARTIFACT_DIR}/revisions.env" <<EOF
 plugin_sha=${PLUGIN_GIT_SHA}
 plugin_dirty=${PLUGIN_DIRTY}
 candle_sha=${CANDLE_SAM3_COMMIT}
 input_sha256=$(sha256sum "${INPUT_STACK}" | awk '{print $1}')
-checkpoint_sha256=$(sha256sum "${CHECKPOINT_PATH}" | awk '{print $1}')
+checkpoint_sha256=${CHECKPOINT_SHA256}
 image_id=$(docker image inspect --format '{{.Id}}' "${BACKEND_IMAGE}")
 cuda_compute_cap=${CUDA_COMPUTE_CAP}
 cuda_device_ordinal=${CUDA_DEVICE_ORDINAL}
+sam3_video_state_profile=${SAM3_VIDEO_STATE_PROFILE}
+sam3_video_feature_cache_entries=${SAM3_VIDEO_FEATURE_CACHE_ENTRIES}
 gpu=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=name --format=csv,noheader 2>/dev/null || printf unavailable)
 driver_version=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=driver_version --format=csv,noheader 2>/dev/null || printf unavailable)
 cuda_runtime=$(docker run --rm --entrypoint /bin/sh "${BACKEND_IMAGE}" -c 'printf %s "${CUDA_VERSION:-unknown}"')
@@ -233,23 +260,39 @@ if [[ "${SKIP_GPU_CHECK:-0}" != "1" ]]; then
 fi
 
 log "Staging input and checkpoint in Docker volume: ${VOLUME_NAME}"
-docker volume create "${VOLUME_NAME}" >/dev/null
-docker run --rm \
-  --entrypoint /bin/sh \
-  -v "${VOLUME_NAME}:/volume" \
-  -v "${INPUT_DIR}:/input:ro" \
-  -v "${CHECKPOINT_DIR}:/checkpoint:ro" \
-  -e INPUT_NAME="${INPUT_NAME}" \
-  -e CHECKPOINT_NAME="${CHECKPOINT_NAME}" \
-  -e OUTPUT_NAME="${OUTPUT_NAME}" \
-  "${BACKEND_IMAGE}" \
-  -ceu '
-    plugin_root=/volume/sam3-segmentation
-    mkdir -p "${plugin_root}/chkpts" "${plugin_root}/Segmentation"
-    rm -f "${plugin_root}/${INPUT_NAME}" "${plugin_root}/Segmentation/${OUTPUT_NAME}"
-    cp "/input/${INPUT_NAME}" "${plugin_root}/${INPUT_NAME}"
-    cp "/checkpoint/${CHECKPOINT_NAME}" "${plugin_root}/chkpts/medical_sam3.pt"
-  '
+if [[ "${REUSE_STAGED_CHECKPOINT}" == "1" ]]; then
+  docker run --rm \
+    --entrypoint /bin/sh \
+    -v "${VOLUME_NAME}:/volume" \
+    -v "${INPUT_DIR}:/input:ro" \
+    -e INPUT_NAME="${INPUT_NAME}" \
+    -e OUTPUT_NAME="${OUTPUT_NAME}" \
+    "${BACKEND_IMAGE}" \
+    -ceu '
+      plugin_root=/volume/sam3-segmentation
+      test -s "${plugin_root}/chkpts/medical_sam3.pt"
+      mkdir -p "${plugin_root}/Segmentation"
+      rm -f "${plugin_root}/${INPUT_NAME}" "${plugin_root}/Segmentation/${OUTPUT_NAME}"
+      cp "/input/${INPUT_NAME}" "${plugin_root}/${INPUT_NAME}"
+    '
+else
+  docker run --rm \
+    --entrypoint /bin/sh \
+    -v "${VOLUME_NAME}:/volume" \
+    -v "${INPUT_DIR}:/input:ro" \
+    -v "${CHECKPOINT_DIR}:/checkpoint:ro" \
+    -e INPUT_NAME="${INPUT_NAME}" \
+    -e CHECKPOINT_NAME="${CHECKPOINT_NAME}" \
+    -e OUTPUT_NAME="${OUTPUT_NAME}" \
+    "${BACKEND_IMAGE}" \
+    -ceu '
+      plugin_root=/volume/sam3-segmentation
+      mkdir -p "${plugin_root}/chkpts" "${plugin_root}/Segmentation"
+      rm -f "${plugin_root}/${INPUT_NAME}" "${plugin_root}/Segmentation/${OUTPUT_NAME}"
+      cp "/input/${INPUT_NAME}" "${plugin_root}/${INPUT_NAME}"
+      cp "/checkpoint/${CHECKPOINT_NAME}" "${plugin_root}/chkpts/medical_sam3.pt"
+    '
+fi
 
 trap cleanup EXIT
 
@@ -263,6 +306,8 @@ docker run -d \
   -e VOLUME_MOUNT_PATH=/ouroboros-volume \
   -e VOLUME_SERVER_URL=http://host.docker.internal:3001 \
   -e CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL}" \
+  -e SAM3_VIDEO_STATE_PROFILE="${SAM3_VIDEO_STATE_PROFILE}" \
+  -e SAM3_VIDEO_FEATURE_CACHE_ENTRIES="${SAM3_VIDEO_FEATURE_CACHE_ENTRIES}" \
   --add-host host.docker.internal:host-gateway \
   "${BACKEND_IMAGE}" >/dev/null
 

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -30,6 +30,7 @@ Common options:
   TELEMETRY_INTERVAL_SECONDS=1  Sampling interval for GPU, RSS, and elapsed-time CSV rows.
   SAM3_VIDEO_STATE_PROFILE=cpu-offload  State profile: gpu-resident (B) or cpu-offload (C).
   SAM3_VIDEO_FEATURE_CACHE_ENTRIES=1    Feature-cache capacity benchmark control: 1 or 2.
+  SAM3_TRACKER_TRIM_PAST_NON_COND_MEM=true  Enable the mask-memory trim control.
   TIFF_VALIDATOR_PYTHON=python3  Python interpreter with tifffile and numpy installed.
   KEEP_CONTAINER=1               Leave the backend container running after the script exits.
 
@@ -165,6 +166,7 @@ OVERLAY_ANNOTATION_POINTS="${OVERLAY_ANNOTATION_POINTS:-false}"
 REUSE_STAGED_CHECKPOINT="${REUSE_STAGED_CHECKPOINT:-0}"
 SAM3_VIDEO_STATE_PROFILE="${SAM3_VIDEO_STATE_PROFILE:-cpu-offload}"
 SAM3_VIDEO_FEATURE_CACHE_ENTRIES="${SAM3_VIDEO_FEATURE_CACHE_ENTRIES:-1}"
+SAM3_TRACKER_TRIM_PAST_NON_COND_MEM="${SAM3_TRACKER_TRIM_PAST_NON_COND_MEM:-true}"
 if [[ -x "${BACKEND_DIR}/.venv/bin/python" ]]; then
   DEFAULT_TIFF_VALIDATOR_PYTHON="${BACKEND_DIR}/.venv/bin/python"
 else
@@ -249,6 +251,7 @@ cuda_compute_cap=${CUDA_COMPUTE_CAP}
 cuda_device_ordinal=${CUDA_DEVICE_ORDINAL}
 sam3_video_state_profile=${SAM3_VIDEO_STATE_PROFILE}
 sam3_video_feature_cache_entries=${SAM3_VIDEO_FEATURE_CACHE_ENTRIES}
+sam3_tracker_trim_past_non_cond_mem=${SAM3_TRACKER_TRIM_PAST_NON_COND_MEM}
 gpu=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=name --format=csv,noheader 2>/dev/null || printf unavailable)
 driver_version=$(nvidia-smi --id="${CUDA_DEVICE_ORDINAL}" --query-gpu=driver_version --format=csv,noheader 2>/dev/null || printf unavailable)
 cuda_runtime=$(docker run --rm --entrypoint /bin/sh "${BACKEND_IMAGE}" -c 'printf %s "${CUDA_VERSION:-unknown}"')
@@ -308,6 +311,7 @@ docker run -d \
   -e CUDA_DEVICE_ORDINAL="${CUDA_DEVICE_ORDINAL}" \
   -e SAM3_VIDEO_STATE_PROFILE="${SAM3_VIDEO_STATE_PROFILE}" \
   -e SAM3_VIDEO_FEATURE_CACHE_ENTRIES="${SAM3_VIDEO_FEATURE_CACHE_ENTRIES}" \
+  -e SAM3_TRACKER_TRIM_PAST_NON_COND_MEM="${SAM3_TRACKER_TRIM_PAST_NON_COND_MEM}" \
   --add-host host.docker.internal:host-gateway \
   "${BACKEND_IMAGE}" >/dev/null
 

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -58,7 +58,7 @@ pub fn load_sam3_handle(
         sam3::Sam3ImageModel::from_checkpoint_source(&config, &source, DType::F32, &device)
             .map_err(|e| AppError::internal(e.to_string()))?;
     let mut tracker_config = sam3::Sam3TrackerConfig::from_sam3_config(&config);
-    tracker_config.predictor.trim_past_non_cond_mem_for_eval = true;
+    tracker_config.predictor.trim_past_non_cond_mem_for_eval = configured_trim_past_non_cond_mem()?;
     info!(
         trim_past_non_cond_mem_for_eval = tracker_config.predictor.trim_past_non_cond_mem_for_eval,
         hotstart_delay = tracker_config.predictor.hotstart_delay,
@@ -267,11 +267,17 @@ fn run_video_inference(
                 tracked_objects = cache_stats.tracked_objects,
                 cpu_total_bytes = cache_stats.cpu_bytes.total(),
                 cpu_frame_bytes = cache_stats.cpu_bytes.frames,
+                cpu_visual_feature_bytes = cache_stats.cpu_bytes.visual_features,
                 cpu_tracker_state_bytes = cache_stats.cpu_bytes.tracker_states,
+                cpu_packed_prompt_history_bytes = cache_stats.cpu_bytes.packed_prompt_history,
+                cpu_text_cache_bytes = cache_stats.cpu_bytes.text_cache,
                 cpu_cached_output_bytes = cache_stats.cpu_bytes.cached_outputs,
                 device_total_bytes = cache_stats.device_bytes.total(),
                 device_frame_bytes = cache_stats.device_bytes.frames,
+                device_visual_feature_bytes = cache_stats.device_bytes.visual_features,
                 device_tracker_state_bytes = cache_stats.device_bytes.tracker_states,
+                device_packed_prompt_history_bytes = cache_stats.device_bytes.packed_prompt_history,
+                device_text_cache_bytes = cache_stats.device_bytes.text_cache,
                 device_cached_output_bytes = cache_stats.device_bytes.cached_outputs,
                 "completed streamed SAM3 video propagation"
             );
@@ -418,6 +424,25 @@ fn register_single_trajectory_prompts(
 
 const VIDEO_STATE_PROFILE_ENV: &str = "SAM3_VIDEO_STATE_PROFILE";
 const VIDEO_FEATURE_CACHE_ENTRIES_ENV: &str = "SAM3_VIDEO_FEATURE_CACHE_ENTRIES";
+const TRACKER_TRIM_PAST_NON_COND_MEM_ENV: &str = "SAM3_TRACKER_TRIM_PAST_NON_COND_MEM";
+
+fn configured_trim_past_non_cond_mem() -> Result<bool, AppError> {
+    parse_trim_past_non_cond_mem(
+        std::env::var(TRACKER_TRIM_PAST_NON_COND_MEM_ENV)
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn parse_trim_past_non_cond_mem(value: Option<&str>) -> Result<bool, AppError> {
+    match value.unwrap_or("true") {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        value => Err(AppError::bad_request(format!(
+            "Invalid {TRACKER_TRIM_PAST_NON_COND_MEM_ENV}={value:?}; expected true or false"
+        ))),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VideoStateProfile {
@@ -538,6 +563,14 @@ mod tests {
         assert!(low_memory_video_session_config(None, Some("0")).is_err());
         assert!(low_memory_video_session_config(None, Some("3")).is_err());
         assert!(low_memory_video_session_config(None, Some("many")).is_err());
+    }
+
+    #[test]
+    fn tracker_trim_control_defaults_on_and_supports_an_untrimmed_reference() {
+        assert!(parse_trim_past_non_cond_mem(None).expect("default trim"));
+        assert!(parse_trim_past_non_cond_mem(Some("true")).expect("trimmed control"));
+        assert!(!parse_trim_past_non_cond_mem(Some("false")).expect("untrimmed control"));
+        assert!(parse_trim_past_non_cond_mem(Some("yes")).is_err());
     }
 
     #[test]

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -57,9 +57,20 @@ pub fn load_sam3_handle(
     let image_model =
         sam3::Sam3ImageModel::from_checkpoint_source(&config, &source, DType::F32, &device)
             .map_err(|e| AppError::internal(e.to_string()))?;
-    let tracker =
-        sam3::Sam3TrackerModel::from_checkpoint_source(&config, &source, DType::F32, &device)
-            .map_err(|e| AppError::internal(e.to_string()))?;
+    let mut tracker_config = sam3::Sam3TrackerConfig::from_sam3_config(&config);
+    tracker_config.predictor.trim_past_non_cond_mem_for_eval = true;
+    info!(
+        trim_past_non_cond_mem_for_eval = tracker_config.predictor.trim_past_non_cond_mem_for_eval,
+        hotstart_delay = tracker_config.predictor.hotstart_delay,
+        "configured SAM3 tracker retention controls"
+    );
+    let tracker = sam3::Sam3TrackerModel::new(
+        &tracker_config,
+        source
+            .load_tracker_var_builder(DType::F32, &device)
+            .map_err(|e| AppError::internal(e.to_string()))?,
+    )
+    .map_err(|e| AppError::internal(e.to_string()))?;
     Ok(Sam3ModelHandle {
         model_name,
         image_model: Arc::new(image_model),
@@ -161,7 +172,17 @@ fn run_video_inference(
 
     let source =
         sam3::VideoSource::from_path(frames_dir).map_err(|e| AppError::internal(e.to_string()))?;
-    let session_options = low_memory_video_session_options();
+    let session_config = configured_low_memory_video_session()?;
+    let session_options = session_config.options.clone();
+    info!(
+        state_profile = session_config.state_profile.as_str(),
+        offload_state_to_cpu = session_options.offload_state_to_cpu,
+        offload_frames_to_cpu = session_options.offload_frames_to_cpu,
+        prefetch_ahead = session_options.prefetch_ahead,
+        prefetch_behind = session_options.prefetch_behind,
+        max_feature_cache_entries = session_options.max_feature_cache_entries,
+        "configured low-memory SAM3 video session"
+    );
 
     let model_ref = &*handle.image_model;
     let tracker_ref = &*handle.tracker;
@@ -239,7 +260,19 @@ fn run_video_inference(
                 .session_cache_stats(&session_id)
                 .map_err(|e| AppError::internal(e.to_string()))?;
             info!(
+                state_profile = session_config.state_profile.as_str(),
+                loaded_frame_count = cache_stats.loaded_frame_count,
+                cached_feature_entries = cache_stats.cached_feature_entries,
                 cached_output_frames = cache_stats.cached_output_frames,
+                tracked_objects = cache_stats.tracked_objects,
+                cpu_total_bytes = cache_stats.cpu_bytes.total(),
+                cpu_frame_bytes = cache_stats.cpu_bytes.frames,
+                cpu_tracker_state_bytes = cache_stats.cpu_bytes.tracker_states,
+                cpu_cached_output_bytes = cache_stats.cpu_bytes.cached_outputs,
+                device_total_bytes = cache_stats.device_bytes.total(),
+                device_frame_bytes = cache_stats.device_bytes.frames,
+                device_tracker_state_bytes = cache_stats.device_bytes.tracker_states,
+                device_cached_output_bytes = cache_stats.device_bytes.cached_outputs,
                 "completed streamed SAM3 video propagation"
             );
             if cache_stats.cached_output_frames != 0 {
@@ -383,16 +416,78 @@ fn register_single_trajectory_prompts(
     })
 }
 
-fn low_memory_video_session_options() -> sam3::VideoSessionOptions {
-    sam3::VideoSessionOptions {
-        tokenizer_path: None,
-        memory_profile: sam3::VideoMemoryProfile::LowMemory,
-        offload_frames_to_cpu: false,
-        offload_state_to_cpu: false,
-        prefetch_ahead: 0,
-        prefetch_behind: 0,
-        max_feature_cache_entries: 2,
+const VIDEO_STATE_PROFILE_ENV: &str = "SAM3_VIDEO_STATE_PROFILE";
+const VIDEO_FEATURE_CACHE_ENTRIES_ENV: &str = "SAM3_VIDEO_FEATURE_CACHE_ENTRIES";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VideoStateProfile {
+    GpuResident,
+    CpuOffload,
+}
+
+impl VideoStateProfile {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::GpuResident => "gpu-resident",
+            Self::CpuOffload => "cpu-offload",
+        }
     }
+}
+
+#[derive(Debug, Clone)]
+struct LowMemoryVideoSessionConfig {
+    state_profile: VideoStateProfile,
+    options: sam3::VideoSessionOptions,
+}
+
+fn configured_low_memory_video_session() -> Result<LowMemoryVideoSessionConfig, AppError> {
+    low_memory_video_session_config(
+        std::env::var(VIDEO_STATE_PROFILE_ENV).ok().as_deref(),
+        std::env::var(VIDEO_FEATURE_CACHE_ENTRIES_ENV)
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn low_memory_video_session_config(
+    state_profile: Option<&str>,
+    feature_cache_entries: Option<&str>,
+) -> Result<LowMemoryVideoSessionConfig, AppError> {
+    let state_profile = match state_profile.unwrap_or("cpu-offload") {
+        "gpu-resident" => VideoStateProfile::GpuResident,
+        "cpu-offload" => VideoStateProfile::CpuOffload,
+        value => {
+            return Err(AppError::bad_request(format!(
+                "Invalid {VIDEO_STATE_PROFILE_ENV}={value:?}; expected gpu-resident or cpu-offload"
+            )))
+        }
+    };
+    let max_feature_cache_entries = feature_cache_entries
+        .unwrap_or("1")
+        .parse::<usize>()
+        .map_err(|_| {
+            AppError::bad_request(format!(
+                "Invalid {VIDEO_FEATURE_CACHE_ENTRIES_ENV}; expected 1 or 2"
+            ))
+        })?;
+    if !matches!(max_feature_cache_entries, 1 | 2) {
+        return Err(AppError::bad_request(format!(
+            "Invalid {VIDEO_FEATURE_CACHE_ENTRIES_ENV}={max_feature_cache_entries}; expected 1 or 2"
+        )));
+    }
+
+    Ok(LowMemoryVideoSessionConfig {
+        state_profile,
+        options: sam3::VideoSessionOptions {
+            tokenizer_path: None,
+            memory_profile: sam3::VideoMemoryProfile::LowMemory,
+            offload_frames_to_cpu: false,
+            offload_state_to_cpu: matches!(state_profile, VideoStateProfile::CpuOffload),
+            prefetch_ahead: 0,
+            prefetch_behind: 0,
+            max_feature_cache_entries,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -409,19 +504,40 @@ mod tests {
     }
 
     #[test]
-    fn video_session_options_use_low_memory_no_prefetch_profile() {
-        let options = low_memory_video_session_options();
+    fn video_session_options_default_to_cpu_offload_and_one_feature() {
+        let config = low_memory_video_session_config(None, None).expect("default profile");
+        let options = config.options;
 
+        assert_eq!(config.state_profile, VideoStateProfile::CpuOffload);
         assert!(matches!(
             options.memory_profile,
             sam3::VideoMemoryProfile::LowMemory
         ));
         assert!(!options.offload_frames_to_cpu);
-        assert!(!options.offload_state_to_cpu);
+        assert!(options.offload_state_to_cpu);
         assert_eq!(options.prefetch_ahead, 0);
         assert_eq!(options.prefetch_behind, 0);
-        assert_eq!(options.max_feature_cache_entries, 2);
+        assert_eq!(options.max_feature_cache_entries, 1);
         assert!(options.tokenizer_path.is_none());
+    }
+
+    #[test]
+    fn video_session_options_expose_benchmark_variants_and_reject_ambiguity() {
+        let gpu =
+            low_memory_video_session_config(Some("gpu-resident"), Some("2")).expect("variant B");
+        assert_eq!(gpu.state_profile, VideoStateProfile::GpuResident);
+        assert!(!gpu.options.offload_state_to_cpu);
+        assert_eq!(gpu.options.max_feature_cache_entries, 2);
+
+        let cpu =
+            low_memory_video_session_config(Some("cpu-offload"), Some("1")).expect("variant C");
+        assert_eq!(cpu.state_profile, VideoStateProfile::CpuOffload);
+        assert!(cpu.options.offload_state_to_cpu);
+
+        assert!(low_memory_video_session_config(Some("auto"), None).is_err());
+        assert!(low_memory_video_session_config(None, Some("0")).is_err());
+        assert!(low_memory_video_session_config(None, Some("3")).is_err());
+        assert!(low_memory_video_session_config(None, Some("many")).is_err());
     }
 
     #[test]

--- a/docs/CANDLE2_LOW_MEMORY_PROFILE.md
+++ b/docs/CANDLE2_LOW_MEMORY_PROFILE.md
@@ -26,6 +26,8 @@ reduces the non-conditioning mask-memory window; it does **not** bound the full
 tracker history lands in https://github.com/den-sq/sam_parity/issues/37, CPU
 offload is therefore a temporary capacity measure rather than a claim that
 retained history is bounded.
+Set `SAM3_TRACKER_TRIM_PAST_NON_COND_MEM=false` only for the required untrimmed
+reference run; the default is `true`, and the selected masks must remain equal.
 
 The Medical tracker control has `hotstart_delay=0`, so there is no enabled
 hotstart queue in these measurements. Any future non-zero hotstart delay must be

--- a/docs/CANDLE2_LOW_MEMORY_PROFILE.md
+++ b/docs/CANDLE2_LOW_MEMORY_PROFILE.md
@@ -1,0 +1,51 @@
+# CANDLE-2 low-memory video profile
+
+Tracking issue: https://github.com/den-sq/sam_parity/issues/33
+
+The temporary production default is variant C: compact low-memory outputs with
+tracker state offloaded to CPU, zero frame prefetch, and one cached feature entry.
+Variant B keeps tracker state on the GPU and is available as a benchmark control.
+It must not become the default until the 512-frame workload demonstrates both a
+14 GiB peak-VRAM ceiling and a post-warmup memory plateau.
+
+| Setting | Variant B | Variant C (default) |
+| --- | --- | --- |
+| `SAM3_VIDEO_STATE_PROFILE` | `gpu-resident` | `cpu-offload` |
+| `offload_state_to_cpu` | false | true |
+| `SAM3_VIDEO_FEATURE_CACHE_ENTRIES` | 1 or 2 | 1 or 2 |
+| frame prefetch | 0 | 0 |
+
+The backend logs the selected profile, loaded-frame count, feature-cache count,
+and separate CPU/device byte totals for frames, tracker state, and cached output.
+The GPU smoke harness also records host/container RSS, CUDA memory, utilization,
+elapsed time, exact revisions, and output hashes.
+
+`trim_past_non_cond_mem_for_eval` is enabled as the mask-memory control. This
+reduces the non-conditioning mask-memory window; it does **not** bound the full
+`tracker_states` map or its F32 `288 x 288` low-resolution masks. Until bounded
+tracker history lands in https://github.com/den-sq/sam_parity/issues/37, CPU
+offload is therefore a temporary capacity measure rather than a claim that
+retained history is bounded.
+
+The Medical tracker control has `hotstart_delay=0`, so there is no enabled
+hotstart queue in these measurements. Any future non-zero hotstart delay must be
+reported as separate bounded transient retention, not tracker-history growth.
+
+## Benchmark matrix
+
+Run `backend/scripts/benchmark_low_memory_profiles_gpu.sh` with a local Medical
+SAM3 checkpoint and representative annotated TIFF. It generates deterministic
+32-, 128-, and 512-frame workloads, runs B before C, compares feature-cache
+capacity one versus two, and writes per-run logs plus `summary.csv`.
+Set `REUSE_STAGED_CHECKPOINT=1` and `VOLUME_NAME` to reuse a private checkpoint
+already staged in Docker without creating another 10 GB checkpoint copy.
+
+The matrix deliberately retains the existing transformer-owned frame adapter.
+The caller-owned lazy adapter in https://github.com/den-sq/sam_parity/issues/41
+is deferred until its preprocessing golden passes. This keeps media-adapter
+ownership and process-start effects out of the state-offload attribution.
+
+Output D2H streaming is common to both variants. The difference between B and C
+therefore measures repeated tracker-state offload/reload overhead; the external
+CUDA telemetry remains the total transfer/control observation until Candle
+exposes direction-specific PCIe counters.


### PR DESCRIPTION
## Summary

Adds explicit, observable low-memory SAM3 video session profiles and a disk-safe GPU benchmark matrix for https://github.com/den-sq/sam_parity/issues/33.

Variant C (`cpu-offload`) is the certified temporary default. Variant B (`gpu-resident`) remains opt-in: it is faster, but retained live tracker state grows with frame count and therefore fails the no-growth gate despite staying below 14 GiB in the 512-frame run.

## Changes

- updates the plugin consumer to Candle 0.11
- pins CUDA builds to https://github.com/den-sq/candle_sam3/pull/4 at `5b923247529646f3e1f59fefa60b3d6cca137b7b`
- exposes `gpu-resident` and `cpu-offload` state profiles
- exposes feature-cache capacity 1 or 2; defaults to 1
- retains lazy CPU frame storage and zero prefetch
- enables `trim_past_non_cond_mem_for_eval` by default and exposes an explicit untrimmed control
- logs separate CPU/device retention bytes for frames, features, tracker states, packed prompt history, text cache, and cached outputs
- records `hotstart_delay=0` separately from retained tracker history
- adds a 32/128/512 B/C benchmark harness with a disk-space floor
- supports reusing a private checkpoint already staged in Docker, avoiding another 10 GB copy
- explicitly defers the caller-owned adapter in https://github.com/den-sq/sam_parity/issues/41 so adapter ownership does not contaminate state-profile attribution

## Exact CUDA certification

Image: `sha256:701a6fba08f9bb1e40e797fb76c6eb8555390f8934ff69e0f870dabd43a556fa` (`plugin=29cefe750f771f101f53a79a00e93b7a69341b12`, `candle=5b923247529646f3e1f59fefa60b3d6cca137b7b`).

| Frames | Profile | Cache | Elapsed | Peak VRAM | Tracker-state bytes | Output SHA-256 |
| ---: | --- | ---: | ---: | ---: | ---: | --- |
| 32 | GPU resident | 2 | 148 s | 9,553 MiB | 31,883,392 device | `1f0073df16063c379599da33f4af10f913b4a08be4ce6494aa7fa0198a4df4ea` |
| 32 | CPU offload | 2 | 181 s | 7,505 MiB | 31,883,392 CPU | `1f0073df16063c379599da33f4af10f913b4a08be4ce6494aa7fa0198a4df4ea` |
| 128 | GPU resident | 1 | 539 s | 9,169 MiB | 63,832,576 device | `4fc0d5e2d03809a61b14e75efe096d7c98d45c95ba546fa812e4c13fc7d75825` |
| 128 | CPU offload | 1 | 626 s | 7,505 MiB | 63,832,576 CPU | `4fc0d5e2d03809a61b14e75efe096d7c98d45c95ba546fa812e4c13fc7d75825` |
| 512 | GPU resident | 1 | 2,093 s | 9,169 MiB | 191,629,312 device | `e32a1de2600f1e8f83ebb919ae712564f83e12dcf04fb217de8c0d59ddea4904` |
| 512 | CPU offload | 1 | 2,402 s | 7,537 MiB | 191,629,312 CPU | `e32a1de2600f1e8f83ebb919ae712564f83e12dcf04fb217de8c0d59ddea4904` |

At every checkpoint the B/C outputs are byte-identical. Both profiles retain one loaded frame, one cached feature, zero cached outputs, and one tracked object. B is approximately 14.8% faster at 512 frames, while C saves 1,632 MiB peak VRAM and moves the linearly growing tracker state to host memory. C therefore remains the default until bounded history is integrated by https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/pull/46 and https://github.com/den-sq/candle_sam3/pull/5.

### Constructor, trimming, and cache controls

- the exact explicit-constructor 32-frame trimmed and untrimmed C runs are byte-identical to each other and to the helper/default B/C output above
- the first 16 frames are byte-identical to the streamed control from https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/pull/44
- cache capacities 1 and 2 produce identical masks
- cache 2 adds 384 MiB peak VRAM to the 32-frame GPU-resident run without an output benefit, supporting cache 1 as the default

The output device-to-host path is common to both profiles; the B/C delta isolates tracker-state residency/offload at the profile level. No private checkpoint, input TIFF, or output TIFF is committed or redistributed.

## Verification

- backend Rust unit suite: 65 passed; one checkpoint-dependent test ignored
- annotation contract test passed
- Python network suite: 19 passed
- Candle SAM3 video subset in https://github.com/den-sq/candle_sam3/pull/4: 14 passed
- full Candle transformer suite: 54 passed, 4 ignored
- exact 32/128/512 CUDA matrix and controls above
- shell syntax checks for both GPU harnesses
- `git diff --check`

## Stack

Base: https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/pull/44 (`codex/candle-2-04-streaming`)

Candle companion: https://github.com/den-sq/candle_sam3/pull/4
