### PR TITLE
CANDLE-2: report frame progress and reconnect jobs

### DIFF
--- a/backend/src/api/jobs.rs
+++ b/backend/src/api/jobs.rs
@@ -109,6 +109,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fresh_client_reads_committed_progress_during_initial_hotstart_delay() {
+        const HOTSTART_DELAY: usize = 4;
+        assert!(HOTSTART_DELAY > 0);
+
+        let state = state();
+        state.create_job("delayed".into()).await;
+        // Inference has started, but a positive hotstart delay means that no
+        // frame callback has been emitted yet. Transferring=100 and
+        // Inference=0 are therefore the latest committed values.
+        state
+            .update_job_phase("delayed", JobPhase::Inference, 0)
+            .await;
+
+        let latest = latest_job(State(state.clone())).await.unwrap().0;
+        assert_eq!(latest.job_id.as_deref(), Some("delayed"));
+        assert_eq!(latest.status, "running");
+
+        let record = status(State(state), Path("delayed".into()))
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(record.active_phase, Some(JobPhase::Inference));
+        assert_eq!(record.steps[0].progress, 100);
+        assert_eq!(record.steps[1].progress, 0);
+        assert_eq!(record.steps[2].progress, 0);
+    }
+
+    #[tokio::test]
     async fn latest_job_does_not_reconnect_terminal_jobs() {
         let state = state();
         state.create_job("done".into()).await;

--- a/backend/src/api/jobs.rs
+++ b/backend/src/api/jobs.rs
@@ -63,3 +63,58 @@ pub async fn latest_job(
 
     Ok(Json(response))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{latest_job, status};
+    use crate::{app_state::AppState, config::AppConfig, domain::jobs::JobPhase};
+    use axum::extract::{Path, State};
+    use std::path::PathBuf;
+
+    fn state() -> AppState {
+        AppState::new(AppConfig {
+            plugin_name: "test".into(),
+            volume_name: "test".into(),
+            volume_server_url: "http://127.0.0.1:3001".into(),
+            huggingface_base_url: "https://huggingface.co".into(),
+            checkpoint_dir: PathBuf::from("/tmp/test"),
+            internal_volume_path: PathBuf::from("/tmp/test"),
+            fallback_annotation_interval: 1,
+            bind_address: "127.0.0.1:8686".parse().unwrap(),
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn fresh_client_can_discover_latest_running_job_then_fetch_progress() {
+        let state = state();
+        state.create_job("older".into()).await;
+        state.complete_job("older").await;
+        state.create_job("running".into()).await;
+        state
+            .update_job_phase("running", JobPhase::Inference, 42)
+            .await;
+
+        let latest = latest_job(State(state.clone())).await.unwrap().0;
+        assert_eq!(latest.job_id.as_deref(), Some("running"));
+        assert_eq!(latest.status, "running");
+
+        let record = status(State(state), Path("running".into()))
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(record.active_phase, Some(JobPhase::Inference));
+        assert_eq!(record.steps[0].progress, 100);
+        assert_eq!(record.steps[1].progress, 42);
+    }
+
+    #[tokio::test]
+    async fn latest_job_does_not_reconnect_terminal_jobs() {
+        let state = state();
+        state.create_job("done".into()).await;
+        state.complete_job("done").await;
+        let latest = latest_job(State(state)).await.unwrap().0;
+        assert_eq!(latest.job_id, None);
+        assert_eq!(latest.status, "none");
+    }
+}

--- a/backend/src/app_state.rs
+++ b/backend/src/app_state.rs
@@ -6,7 +6,10 @@ use tokio::sync::{Mutex, RwLock, Semaphore};
 
 use crate::{
     config::AppConfig,
-    domain::{jobs::JobRecord, responses::StartupStatus},
+    domain::{
+        jobs::{JobPhase, JobRecord},
+        responses::StartupStatus,
+    },
     error::AppError,
     inference::registry::ModelRegistry,
 };
@@ -106,15 +109,21 @@ impl AppState {
             .map(|(job_id, record)| (job_id.clone(), record.clone()))
     }
 
-    pub async fn update_job_step(&self, job_id: &str, step_index: usize, progress: u8) {
+    pub async fn update_job_phase(&self, job_id: &str, phase: JobPhase, progress: u8) {
         if let Some(record) = self.jobs.write().await.get_mut(job_id) {
-            record.update_step(step_index, progress);
+            record.update_phase(phase, progress);
         }
     }
 
-    pub async fn set_job_status(&self, job_id: &str, status: &str) {
+    pub async fn complete_job(&self, job_id: &str) {
         if let Some(record) = self.jobs.write().await.get_mut(job_id) {
-            record.set_status(status);
+            record.complete();
+        }
+    }
+
+    pub async fn fail_job(&self, job_id: &str, message: impl Into<String>) {
+        if let Some(record) = self.jobs.write().await.get_mut(job_id) {
+            record.fail(message);
         }
     }
 

--- a/backend/src/domain/jobs.rs
+++ b/backend/src/domain/jobs.rs
@@ -1,6 +1,34 @@
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobPhase {
+    Transferring,
+    Inference,
+    Saving,
+}
+
+impl JobPhase {
+    pub const ALL: [Self; 3] = [Self::Transferring, Self::Inference, Self::Saving];
+
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Transferring => 0,
+            Self::Inference => 1,
+            Self::Saving => 2,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Transferring => "Transferring",
+            Self::Inference => "Inference",
+            Self::Saving => "Saving",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobStep {
     pub name: String,
@@ -11,6 +39,10 @@ pub struct JobStep {
 pub struct JobRecord {
     pub status: String,
     pub steps: Vec<JobStep>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_phase: Option<JobPhase>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     pub created_at: f64,
     pub updated_at: f64,
 }
@@ -20,35 +52,83 @@ impl JobRecord {
         let now = unix_timestamp();
         Self {
             status: "running".to_string(),
-            steps: vec![
-                JobStep {
-                    name: "Transferring".to_string(),
+            steps: JobPhase::ALL
+                .into_iter()
+                .map(|phase| JobStep {
+                    name: phase.name().to_string(),
                     progress: 0,
-                },
-                JobStep {
-                    name: "Inference".to_string(),
-                    progress: 0,
-                },
-                JobStep {
-                    name: "Saving".to_string(),
-                    progress: 0,
-                },
-            ],
+                })
+                .collect(),
+            active_phase: Some(JobPhase::Transferring),
+            error: None,
             created_at: now,
             updated_at: now,
         }
     }
 
-    pub fn update_step(&mut self, step_index: usize, progress: u8) {
-        if let Some(step) = self.steps.get_mut(step_index) {
-            step.progress = progress.min(100);
-            self.updated_at = unix_timestamp();
+    pub fn update_phase(&mut self, phase: JobPhase, progress: u8) {
+        let phase_index = phase.index();
+        for step in self.steps.iter_mut().take(phase_index) {
+            step.progress = 100;
         }
+        if let Some(step) = self.steps.get_mut(phase_index) {
+            step.progress = step.progress.max(progress.min(100));
+        }
+        self.active_phase = Some(phase);
+        self.updated_at = unix_timestamp();
     }
 
-    pub fn set_status(&mut self, status: &str) {
-        self.status = status.to_string();
+    pub fn complete(&mut self) {
+        for step in &mut self.steps {
+            step.progress = 100;
+        }
+        self.status = "completed".to_string();
+        self.active_phase = None;
+        self.error = None;
         self.updated_at = unix_timestamp();
+    }
+
+    pub fn fail(&mut self, message: impl Into<String>) {
+        self.status = "error".to_string();
+        self.error = Some(message.into());
+        self.updated_at = unix_timestamp();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JobPhase, JobRecord};
+
+    #[test]
+    fn phase_progress_is_monotonic_and_completes_prior_phases() {
+        let mut job = JobRecord::new_running();
+        job.update_phase(JobPhase::Transferring, 72);
+        job.update_phase(JobPhase::Transferring, 40);
+        assert_eq!(job.steps[0].progress, 72);
+
+        job.update_phase(JobPhase::Inference, 1);
+        assert_eq!(job.steps[0].progress, 100);
+        assert_eq!(job.steps[1].progress, 1);
+        assert_eq!(job.active_phase, Some(JobPhase::Inference));
+    }
+
+    #[test]
+    fn completion_and_failure_have_coherent_terminal_state() {
+        let mut completed = JobRecord::new_running();
+        completed.update_phase(JobPhase::Saving, 25);
+        completed.complete();
+        assert!(completed.steps.iter().all(|step| step.progress == 100));
+        assert_eq!(completed.active_phase, None);
+
+        let mut failed = JobRecord::new_running();
+        failed.update_phase(JobPhase::Inference, 37);
+        failed.fail("Inference: device unavailable");
+        assert_eq!(failed.status, "error");
+        assert_eq!(failed.active_phase, Some(JobPhase::Inference));
+        assert_eq!(
+            failed.error.as_deref(),
+            Some("Inference: device unavailable")
+        );
     }
 }
 

--- a/backend/src/imaging/output.rs
+++ b/backend/src/imaging/output.rs
@@ -11,6 +11,17 @@ use crate::{
 };
 
 pub async fn write_mask_stack(target: &Path, masks: &[FrameMask]) -> Result<(), AppError> {
+    write_mask_stack_with_progress(target, masks, |_, _| {}).await
+}
+
+pub async fn write_mask_stack_with_progress<F>(
+    target: &Path,
+    masks: &[FrameMask],
+    mut on_frame: F,
+) -> Result<(), AppError>
+where
+    F: FnMut(usize, usize),
+{
     if masks.is_empty() {
         return Err(AppError::bad_request(
             "Mask stack must contain at least one frame",
@@ -21,7 +32,8 @@ pub async fn write_mask_stack(target: &Path, masks: &[FrameMask]) -> Result<(), 
     let expected_height = masks[0].height;
     let pages = masks
         .iter()
-        .map(|mask| {
+        .enumerate()
+        .map(|(frame_index, mask)| {
             if mask.width != expected_width || mask.height != expected_height {
                 return Err(AppError::bad_request(
                     "Mask stack frames must all share the same geometry",
@@ -33,13 +45,15 @@ pub async fn write_mask_stack(target: &Path, masks: &[FrameMask]) -> Result<(), 
                 ));
             }
 
-            Ok(WritableTiffPage {
+            let page = WritableTiffPage {
                 width: mask.width,
                 height: mask.height,
                 channels: 1,
                 pixels: mask.pixels.clone(),
                 description: None,
-            })
+            };
+            on_frame(frame_index, masks.len());
+            Ok(page)
         })
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/backend/src/imaging/preprocess.rs
+++ b/backend/src/imaging/preprocess.rs
@@ -21,7 +21,17 @@ pub struct PreparedFrame {
 }
 
 pub async fn stage_input_frames(frames: &[PreparedFrame]) -> Result<(), AppError> {
-    for prepared in frames {
+    stage_input_frames_with_progress(frames, |_, _| {}).await
+}
+
+pub async fn stage_input_frames_with_progress<F>(
+    frames: &[PreparedFrame],
+    mut on_frame: F,
+) -> Result<(), AppError>
+where
+    F: FnMut(usize, usize),
+{
+    for (frame_index, prepared) in frames.iter().enumerate() {
         if let Some(parent) = prepared.target.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
@@ -30,6 +40,7 @@ pub async fn stage_input_frames(frames: &[PreparedFrame]) -> Result<(), AppError
             PreparedFrameEncoding::Tiff => stage_tiff_frame(prepared)?,
             PreparedFrameEncoding::Jpeg => stage_jpeg_frame(prepared)?,
         }
+        on_frame(frame_index, frames.len());
     }
 
     Ok(())

--- a/backend/src/inference/candle_sam2.rs
+++ b/backend/src/inference/candle_sam2.rs
@@ -7,7 +7,7 @@ use crate::{
     imaging::tiff_io::ImageFrame,
     inference::{
         image::{FrameMask, ImageSegmenter, PositivePointPrompt},
-        video::{VideoFramePrompt, VideoSegmenter},
+        video::{FrameProgressCallback, VideoFramePrompt, VideoSegmenter},
     },
 };
 
@@ -41,6 +41,7 @@ impl VideoSegmenter for CandleSam2VideoSegmenter {
         &self,
         _frames_dir: &Path,
         _prompts: &[VideoFramePrompt],
+        _progress: Option<FrameProgressCallback>,
     ) -> Result<Vec<FrameMask>, AppError> {
         Err(AppError::not_implemented(format!(
             "Candle SAM2 video inference is not implemented yet for {}",

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -16,7 +16,7 @@ use crate::{
             threshold_mask_logits_to_frame, video_frame_to_mask,
         },
         image::{FrameMask, ImageSegmenter, PositivePointPrompt},
-        video::{VideoFramePrompt, VideoSegmenter},
+        video::{FrameProgressCallback, VideoFramePrompt, VideoSegmenter},
     },
 };
 
@@ -155,13 +155,16 @@ impl VideoSegmenter for CandleSam3VideoSegmenter {
         &self,
         frames_dir: &Path,
         prompts: &[VideoFramePrompt],
+        progress: Option<FrameProgressCallback>,
     ) -> Result<Vec<FrameMask>, AppError> {
         let handle = self.handle.clone();
         let frames_dir = frames_dir.to_path_buf();
         let prompts = prompts.to_vec();
-        tokio::task::spawn_blocking(move || run_video_inference(&handle, &frames_dir, &prompts))
-            .await
-            .map_err(|e| AppError::internal(e.to_string()))?
+        tokio::task::spawn_blocking(move || {
+            run_video_inference(&handle, &frames_dir, &prompts, progress.as_ref())
+        })
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?
     }
 }
 
@@ -169,6 +172,7 @@ fn run_video_inference(
     handle: &Sam3ModelHandle,
     frames_dir: &Path,
     prompts: &[VideoFramePrompt],
+    progress: Option<&FrameProgressCallback>,
 ) -> Result<Vec<FrameMask>, AppError> {
     let session_config = configured_low_memory_video_session()?;
     let session_options = session_config.options.clone();
@@ -261,7 +265,11 @@ fn run_video_inference(
                             .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
                         masks
                             .push_forward(frame.frame_idx, mask)
-                            .map_err(|e| candle_core::Error::Msg(e.to_string()))
+                            .map_err(|e| candle_core::Error::Msg(e.to_string()))?;
+                        if let Some(callback) = progress {
+                            callback(frame.frame_idx, frame_count);
+                        }
+                        Ok(())
                     },
                 )
                 .map_err(|e| AppError::internal(e.to_string()))?;

--- a/backend/src/inference/candle_sam3.rs
+++ b/backend/src/inference/candle_sam3.rs
@@ -694,9 +694,13 @@ mod tests {
     }
 
     #[test]
-    fn video_stream_accepts_delayed_prompt_frames_and_burst_callbacks() {
+    fn video_stream_accepts_hotstart_delay_and_burst_callbacks() {
+        let hotstart_delay = parse_hotstart_delay(Some("2")).expect("positive hotstart delay");
+        assert!(hotstart_delay > 0);
+
         let mut forward = VideoMaskCollector::new(5).expect("collector");
-        let forward_batches = [vec![], vec![], vec![0], vec![1], vec![2, 3, 4]];
+        let mut forward_batches = vec![Vec::new(); hotstart_delay];
+        forward_batches.extend([vec![0], vec![1], vec![2, 3, 4]]);
         for batch in forward_batches {
             for frame_idx in batch {
                 forward
@@ -714,7 +718,8 @@ mod tests {
         );
 
         let mut backward = VideoMaskCollector::new(5).expect("collector");
-        let backward_batches = [vec![], vec![], vec![4], vec![3], vec![2, 1, 0]];
+        let mut backward_batches = vec![Vec::new(); hotstart_delay];
+        backward_batches.extend([vec![4], vec![3], vec![2, 1, 0]]);
         for batch in backward_batches {
             for frame_idx in batch {
                 backward

--- a/backend/src/inference/video.rs
+++ b/backend/src/inference/video.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use async_trait::async_trait;
 
@@ -13,6 +13,8 @@ pub struct VideoFramePrompt {
     pub points: Vec<PositivePointPrompt>,
 }
 
+pub type FrameProgressCallback = Arc<dyn Fn(usize, usize) + Send + Sync>;
+
 /// Segmenter that propagates prompts through a stack of staged frame images.
 ///
 /// `frames_dir` must be a directory of JPEG files as written by
@@ -25,5 +27,6 @@ pub trait VideoSegmenter: Send + Sync {
         &self,
         frames_dir: &Path,
         prompts: &[VideoFramePrompt],
+        progress: Option<FrameProgressCallback>,
     ) -> Result<Vec<FrameMask>, AppError>;
 }

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod checkpoints;
 pub mod pipeline;
+pub mod progress;
 pub mod runner;
 pub mod startup;
 pub mod volume;

--- a/backend/src/services/pipeline.rs
+++ b/backend/src/services/pipeline.rs
@@ -5,23 +5,26 @@ use std::{
 
 use crate::{
     app_state::{AppState, Sam3ModelHandle},
-    domain::{paths::parse_mixed_path, requests::ProcessRequest},
+    domain::{jobs::JobPhase, paths::parse_mixed_path, requests::ProcessRequest},
     error::AppError,
     imaging::{
         annotations::{
             annotation_samples_for_video, default_annotations, interpolated_point_for_frame,
             AnnotationPoint, VolumeShape,
         },
-        output::{write_annotation_overlay_stack, write_mask_stack},
-        preprocess::{stage_input_frames, PreparedFrame, PreparedFrameEncoding},
+        output::{write_annotation_overlay_stack, write_mask_stack_with_progress},
+        preprocess::{stage_input_frames_with_progress, PreparedFrame, PreparedFrameEncoding},
         tiff_io::{inspect_volume, read_volume_frames, VolumeInput},
     },
     inference::{
         candle_sam3::{load_sam3_handle, CandleSam3ImageSegmenter, CandleSam3VideoSegmenter},
         image::{FrameMask, ImageSegmenter},
-        video::VideoSegmenter,
+        video::{FrameProgressCallback, VideoSegmenter},
     },
-    services::volume::VolumeFileMapping,
+    services::{
+        progress::{report_frame, report_phase, ProgressSender},
+        volume::VolumeFileMapping,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -109,32 +112,55 @@ pub async fn prepare(
     })
 }
 
-pub async fn run(state: &AppState, job_id: &str, request: &ProcessRequest) -> Result<(), AppError> {
+pub async fn run(
+    state: &AppState,
+    request: &ProcessRequest,
+    progress: &ProgressSender,
+) -> Result<(), AppError> {
     request.validate()?;
 
     let handle = model_handle_for_request(state, &request.model_type).await?;
-
-    state.update_job_step(job_id, 0, 5).await;
 
     let prepared = prepare(state, request).await?;
     if prepared.plan.temp_volume_dir.exists() {
         tokio::fs::remove_dir_all(&prepared.plan.temp_volume_dir).await?;
     }
     tokio::fs::create_dir_all(&prepared.plan.temp_volume_dir).await?;
-    stage_input_frames(&prepared.staged_frames).await?;
-    state.update_job_step(job_id, 1, 30).await;
+    let result = run_prepared(&handle, &prepared, request, progress).await;
+    let cleanup = tokio::fs::remove_dir_all(&prepared.plan.temp_volume_dir).await;
+    match (result, cleanup) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error.into()),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+async fn run_prepared(
+    handle: &Arc<Sam3ModelHandle>,
+    prepared: &PreparedPipelineInput,
+    request: &ProcessRequest,
+    progress: &ProgressSender,
+) -> Result<(), AppError> {
+    stage_input_frames_with_progress(&prepared.staged_frames, |frame, total| {
+        report_frame(progress, JobPhase::Transferring, frame, total)
+    })
+    .await?;
+    report_phase(progress, JobPhase::Inference);
 
     let masks = match request.predictor_type.as_str() {
-        "ImagePredictor" => run_image_predictor(&handle, &prepared).await?,
-        "VideoPredictor" => run_video_predictor(&handle, &prepared).await?,
+        "ImagePredictor" => run_image_predictor(handle, prepared, progress).await?,
+        "VideoPredictor" => run_video_predictor(handle, prepared, progress).await?,
         _ => unreachable!("validated by ProcessRequest::validate"),
     };
-    state.update_job_step(job_id, 2, 70).await;
 
     if let Some(parent) = prepared.plan.volume_output.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    write_mask_stack(&prepared.plan.volume_output, &masks).await?;
+    report_phase(progress, JobPhase::Saving);
+    write_mask_stack_with_progress(&prepared.plan.volume_output, &masks, |frame, total| {
+        report_frame(progress, JobPhase::Saving, frame, total)
+    })
+    .await?;
     if request.overlay_annotation_points {
         write_annotation_overlay_stack(
             &annotation_overlay_path(&prepared.plan.volume_output),
@@ -144,9 +170,6 @@ pub async fn run(state: &AppState, job_id: &str, request: &ProcessRequest) -> Re
         )
         .await?;
     }
-    tokio::fs::remove_dir_all(&prepared.plan.temp_volume_dir).await?;
-    state.update_job_step(job_id, 3, 100).await;
-
     Ok(())
 }
 
@@ -206,6 +229,7 @@ fn inference_device() -> Result<candle_core::Device, AppError> {
 async fn run_image_predictor(
     handle: &Arc<Sam3ModelHandle>,
     prepared: &PreparedPipelineInput,
+    progress: &ProgressSender,
 ) -> Result<Vec<FrameMask>, AppError> {
     let segmenter = CandleSam3ImageSegmenter {
         handle: handle.clone(),
@@ -217,6 +241,12 @@ async fn run_image_predictor(
             .unwrap_or_default();
         let mask = segmenter.segment(&staged.frame, &prompts).await?;
         masks.push(mask);
+        report_frame(
+            progress,
+            JobPhase::Inference,
+            i,
+            prepared.staged_frames.len(),
+        );
     }
     Ok(masks)
 }
@@ -224,14 +254,23 @@ async fn run_image_predictor(
 async fn run_video_predictor(
     handle: &Arc<Sam3ModelHandle>,
     prepared: &PreparedPipelineInput,
+    progress: &ProgressSender,
 ) -> Result<Vec<FrameMask>, AppError> {
     let segmenter = CandleSam3VideoSegmenter {
         handle: handle.clone(),
     };
     let video_prompts =
         annotation_samples_for_video(&prepared.annotation_points, prepared.staged_frames.len());
+    let sender = progress.clone();
+    let callback: FrameProgressCallback = Arc::new(move |frame, total| {
+        report_frame(&sender, JobPhase::Inference, frame, total);
+    });
     let masks = segmenter
-        .segment_video(&prepared.plan.temp_volume_dir, &video_prompts)
+        .segment_video(
+            &prepared.plan.temp_volume_dir,
+            &video_prompts,
+            Some(callback),
+        )
         .await?;
     validate_video_masks(&masks, prepared)?;
     Ok(masks)

--- a/backend/src/services/pipeline/tests.rs
+++ b/backend/src/services/pipeline/tests.rs
@@ -262,7 +262,8 @@ async fn run_requires_downloaded_sam3_checkpoint_before_staging() {
     std::fs::create_dir_all(&plugin_root).expect("create plugin root");
     write_input_volume(&plugin_root.join("input-stack.tif"), None);
 
-    let error = run(&state, "job-1", &sample_request("ImagePredictor"))
+    let (progress, _receiver) = crate::services::progress::channel();
+    let error = run(&state, &sample_request("ImagePredictor"), &progress)
         .await
         .expect_err("run without downloaded model should fail");
 

--- a/backend/src/services/progress.rs
+++ b/backend/src/services/progress.rs
@@ -1,0 +1,113 @@
+use std::collections::HashSet;
+
+use tokio::sync::mpsc;
+
+use crate::{app_state::AppState, domain::jobs::JobPhase};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressEvent {
+    PhaseStarted(JobPhase),
+    Frame {
+        phase: JobPhase,
+        frame_index: usize,
+        total_frames: usize,
+    },
+}
+
+pub type ProgressSender = mpsc::UnboundedSender<ProgressEvent>;
+
+pub fn channel() -> (ProgressSender, mpsc::UnboundedReceiver<ProgressEvent>) {
+    mpsc::unbounded_channel()
+}
+
+pub async fn consume(
+    state: AppState,
+    job_id: String,
+    mut receiver: mpsc::UnboundedReceiver<ProgressEvent>,
+) {
+    let mut seen: [HashSet<usize>; 3] = std::array::from_fn(|_| HashSet::new());
+    let mut reported = [0u8; 3];
+
+    while let Some(event) = receiver.recv().await {
+        match event {
+            ProgressEvent::PhaseStarted(phase) => {
+                state.update_job_phase(&job_id, phase, 0).await;
+            }
+            ProgressEvent::Frame {
+                phase,
+                frame_index,
+                total_frames,
+            } => {
+                if total_frames == 0 || frame_index >= total_frames {
+                    continue;
+                }
+                let phase_index = phase.index();
+                if !seen[phase_index].insert(frame_index) {
+                    continue;
+                }
+                let progress = ((seen[phase_index].len() * 100) / total_frames).min(100) as u8;
+                if progress > reported[phase_index] {
+                    reported[phase_index] = progress;
+                    state.update_job_phase(&job_id, phase, progress).await;
+                }
+            }
+        }
+    }
+}
+
+pub fn report_phase(sender: &ProgressSender, phase: JobPhase) {
+    let _ = sender.send(ProgressEvent::PhaseStarted(phase));
+}
+
+pub fn report_frame(
+    sender: &ProgressSender,
+    phase: JobPhase,
+    frame_index: usize,
+    total_frames: usize,
+) {
+    // A closed receiver means the job has already reached a terminal state.
+    let _ = sender.send(ProgressEvent::Frame {
+        phase,
+        frame_index,
+        total_frames,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{channel, consume, report_frame, report_phase};
+    use crate::{app_state::AppState, config::AppConfig, domain::jobs::JobPhase};
+    use std::path::PathBuf;
+
+    fn state() -> AppState {
+        AppState::new(AppConfig {
+            plugin_name: "test".into(),
+            volume_name: "test".into(),
+            volume_server_url: "http://127.0.0.1:3001".into(),
+            huggingface_base_url: "https://huggingface.co".into(),
+            checkpoint_dir: PathBuf::from("/tmp/test"),
+            internal_volume_path: PathBuf::from("/tmp/test"),
+            fallback_annotation_interval: 1,
+            bind_address: "127.0.0.1:8686".parse().unwrap(),
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn counts_unique_frames_and_ignores_bursts_and_regressions() {
+        let state = state();
+        state.create_job("job".into()).await;
+        let (sender, receiver) = channel();
+        let task = tokio::spawn(consume(state.clone(), "job".into(), receiver));
+        report_phase(&sender, JobPhase::Inference);
+        for frame in [0, 0, 2, 1, 4, 3] {
+            report_frame(&sender, JobPhase::Inference, frame, 5);
+        }
+        drop(sender);
+        task.await.unwrap();
+
+        let job = state.get_job("job").await.unwrap();
+        assert_eq!(job.steps[0].progress, 100);
+        assert_eq!(job.steps[1].progress, 100);
+    }
+}

--- a/backend/src/services/runner.rs
+++ b/backend/src/services/runner.rs
@@ -1,24 +1,41 @@
 use tracing::error;
 
-use crate::{app_state::AppState, domain::requests::ProcessRequest, services::pipeline};
+use crate::{
+    app_state::AppState,
+    domain::requests::ProcessRequest,
+    services::{pipeline, progress},
+};
 
 pub async fn execute_job(state: AppState, job_id: String, request: ProcessRequest) {
+    let (progress_sender, progress_receiver) = progress::channel();
+    let progress_task = tokio::spawn(progress::consume(
+        state.clone(),
+        job_id.clone(),
+        progress_receiver,
+    ));
     let result = state
-        .with_inference_slot(|| async {
-            state.update_job_step(&job_id, 0, 5).await;
-            state.update_job_step(&job_id, 1, 1).await;
-            pipeline::run(&state, &job_id, &request).await
-        })
+        .with_inference_slot(|| pipeline::run(&state, &request, &progress_sender))
         .await;
+    drop(progress_sender);
+    if let Err(error_value) = progress_task.await {
+        error!(job_id = %job_id, error = %error_value, "progress consumer failed");
+    }
 
     match result {
         Ok(()) => {
-            state.update_job_step(&job_id, 2, 100).await;
-            state.set_job_status(&job_id, "completed").await;
+            state.complete_job(&job_id).await;
         }
         Err(error_value) => {
             error!(job_id = %job_id, error = %error_value, "job execution failed");
-            state.set_job_status(&job_id, "error").await;
+            let phase = state
+                .get_job(&job_id)
+                .await
+                .and_then(|record| record.active_phase)
+                .map(|phase| phase.name())
+                .unwrap_or("Unknown");
+            state
+                .fail_job(&job_id, format!("{phase}: {error_value}"))
+                .await;
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
 				"typescript": "^5.9.3",
 				"vite": "^7.3.1",
 				"vite-plugin-static-copy": "^3.2.0",
-				"vite-plugin-webfont-dl": "^3.12.0"
+				"vite-plugin-webfont-dl": "^3.12.0",
+				"vitest": "^3.2.4"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1523,6 +1524,24 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1821,6 +1840,121 @@
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+			"integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+			"integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.7",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+			"integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+			"integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.7",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+			"integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+			"integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+			"integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2059,6 +2193,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2192,6 +2336,16 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/cacheable": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
@@ -2297,6 +2451,23 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2325,6 +2496,16 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2559,6 +2740,16 @@
 				}
 			}
 		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2783,6 +2974,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -3180,6 +3378,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3188,6 +3396,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4298,6 +4516,13 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4306,6 +4531,16 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -4635,6 +4870,23 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -5180,6 +5432,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5199,6 +5458,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
@@ -5353,6 +5626,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/strip-literal/node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5381,6 +5674,20 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
@@ -5428,6 +5735,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -5713,6 +6050,29 @@
 				}
 			}
 		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/vite-plugin-static-copy": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.2.0.tgz",
@@ -5786,6 +6146,92 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+			"integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.7",
+				"@vitest/mocker": "3.2.7",
+				"@vitest/pretty-format": "^3.2.7",
+				"@vitest/runner": "3.2.7",
+				"@vitest/snapshot": "3.2.7",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.7",
+				"@vitest/ui": "3.2.7",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5898,6 +6344,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"build:release": "npm run build && node scripts/prepare-release-artifacts.mjs",
 		"validate:release": "node scripts/validate-release-artifacts.mjs",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+		"test": "vitest run",
 		"preview": "vite preview"
 	},
 	"dependencies": {
@@ -37,6 +38,7 @@
 		"eslint-plugin-react": "^7.37.5",
 		"eslint-plugin-react-refresh": "^0.5.0",
 		"typescript": "^5.9.3",
+		"vitest": "^3.2.4",
 		"vite": "^7.3.1",
 		"vite-plugin-static-copy": "^3.2.0",
 		"vite-plugin-webfont-dl": "^3.12.0"

--- a/src/Page/index.tsx
+++ b/src/Page/index.tsx
@@ -4,6 +4,7 @@ import OptionsPanel from '../components/OptionsPanel';
 import ProgressPanel, { BackendStatus, ErrorEntry, ProgressItem, VolumeServerState } from '../components/ProgressPanel';
 import ModelsPanel from '../components/ModelsPanel';
 import { BACKEND_URL } from '../config';
+import { findRunningJob } from '../jobReconnect';
 
 const MAX_ERRORS = 5;
 const DEDUP_WINDOW_MS = 5000;
@@ -192,47 +193,17 @@ export default function SAM3Page() {
 
         const tryReconnect = async () => {
             const storedJobId = getStoredJobId();
-            let candidateJobId = storedJobId;
-
-            if (!candidateJobId) {
-                try {
-                    const latestRes = await fetch(`${BACKEND_URL}/latest-job`);
-                    if (latestRes.ok) {
-                        const latestData = await latestRes.json();
-                        const latestJobId = latestData?.job_id;
-                        if (typeof latestJobId === 'string' && latestJobId.length > 0) {
-                            candidateJobId = latestJobId;
-                            setStoredJobId(latestJobId);
-                        }
-                    }
-                } catch {
-                    // Ignore; we'll retry later when the backend is stable.
-                }
+            const restored = await findRunningJob(fetch, BACKEND_URL, storedJobId);
+            if (cancelled) return;
+            if (!restored) {
+                if (storedJobId) clearStoredJobId();
+                return;
             }
-
-            if (!candidateJobId) return;
-
-            try {
-                const res = await fetch(`${BACKEND_URL}/status/${candidateJobId}`);
-                if (!res.ok) {
-                    clearStoredJobId();
-                    return;
-                }
-                const data = await res.json();
-                if (cancelled) return;
-                if (Array.isArray(data.steps)) {
-                    setProg(data.steps);
-                }
-                if (data.status === 'completed' || data.status === 'error') {
-                    clearStoredJobId();
-                    return;
-                }
-                setJobId(candidateJobId);
-                setRun(true);
-                scheduleReconnectBannerClear();
-            } catch {
-                // Keep stored job id for a later reconnect attempt.
-            }
+            setProg(restored.record.steps);
+            setJobId(restored.jobId);
+            setStoredJobId(restored.jobId);
+            setRun(true);
+            scheduleReconnectBannerClear();
         };
 
         tryReconnect();
@@ -249,6 +220,9 @@ export default function SAM3Page() {
                         const data = await res.json();
                         setProg(data.steps);
                         if(data.status === 'completed' || data.status === 'error') {
+                            if (data.status === 'error') {
+                                addError(data.error ?? `${data.active_phase ?? 'Unknown'} phase failed`);
+                            }
                             setRun(false);
                             setJobId(null);
                             clearStoredJobId();

--- a/src/jobReconnect.test.ts
+++ b/src/jobReconnect.test.ts
@@ -10,6 +10,15 @@ const running = {
     ],
 };
 
+const waitingForHotstartCallbacks = {
+    ...running,
+    steps: [
+        { name: 'Transferring', progress: 100 },
+        { name: 'Inference', progress: 0 },
+        { name: 'Saving', progress: 0 },
+    ],
+};
+
 function response(body: unknown, ok = true) {
     return { ok, json: async () => body };
 }
@@ -27,6 +36,23 @@ describe('findRunningJob', () => {
             discoveredFromLatest: true,
         });
         expect(fetcher).toHaveBeenCalledWith('/api/status/remote-job');
+    });
+
+    it('restores the latest committed progress during the initial hotstart delay', async () => {
+        const hotstartDelay = 4;
+        expect(hotstartDelay).toBeGreaterThan(0);
+        const fetcher = vi.fn(async (url: string) => (
+            url.endsWith('/latest-job')
+                ? response({ job_id: 'delayed-job' })
+                : response(waitingForHotstartCallbacks)
+        ));
+
+        await expect(findRunningJob(fetcher, '/api', null)).resolves.toEqual({
+            jobId: 'delayed-job',
+            record: waitingForHotstartCallbacks,
+            discoveredFromLatest: true,
+        });
+        expect(fetcher).toHaveBeenCalledWith('/api/status/delayed-job');
     });
 
     it('falls back to latest-job when a persisted job is stale', async () => {

--- a/src/jobReconnect.test.ts
+++ b/src/jobReconnect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { findRunningJob } from './jobReconnect';
+
+const running = {
+    status: 'running',
+    steps: [
+        { name: 'Transferring', progress: 100 },
+        { name: 'Inference', progress: 37 },
+        { name: 'Saving', progress: 0 },
+    ],
+};
+
+function response(body: unknown, ok = true) {
+    return { ok, json: async () => body };
+}
+
+describe('findRunningJob', () => {
+    it('discovers and restores a running job for a fresh client', async () => {
+        const fetcher = vi.fn(async (url: string) => (
+            url.endsWith('/latest-job')
+                ? response({ job_id: 'remote-job' })
+                : response(running)
+        ));
+        await expect(findRunningJob(fetcher, '/api', null)).resolves.toEqual({
+            jobId: 'remote-job',
+            record: running,
+            discoveredFromLatest: true,
+        });
+        expect(fetcher).toHaveBeenCalledWith('/api/status/remote-job');
+    });
+
+    it('falls back to latest-job when a persisted job is stale', async () => {
+        const fetcher = vi.fn(async (url: string) => {
+            if (url.endsWith('/latest-job')) return response({ job_id: 'active-job' });
+            if (url.endsWith('/status/stale-job')) return response({}, false);
+            return response(running);
+        });
+        const result = await findRunningJob(fetcher, '/api', 'stale-job');
+        expect(result?.jobId).toBe('active-job');
+    });
+
+    it('does not reconnect terminal jobs', async () => {
+        const fetcher = vi.fn(async (url: string) => (
+            url.endsWith('/latest-job')
+                ? response({ job_id: 'done-job' })
+                : response({ ...running, status: 'completed' })
+        ));
+        await expect(findRunningJob(fetcher, '/api', null)).resolves.toBeNull();
+    });
+});

--- a/src/jobReconnect.ts
+++ b/src/jobReconnect.ts
@@ -1,0 +1,58 @@
+import type { ProgressItem } from './components/ProgressPanel';
+
+export type JobStatusRecord = {
+    status: 'running' | 'completed' | 'error' | string;
+    steps: ProgressItem[];
+    active_phase?: string;
+    error?: string;
+};
+
+export type ReconnectedJob = {
+    jobId: string;
+    record: JobStatusRecord;
+    discoveredFromLatest: boolean;
+};
+
+type FetchResponse = {
+    ok: boolean;
+    json(): Promise<unknown>;
+};
+
+export async function findRunningJob(
+    fetcher: (url: string) => Promise<FetchResponse>,
+    backendUrl: string,
+    storedJobId: string | null,
+): Promise<ReconnectedJob | null> {
+    const candidates: Array<{ jobId: string; discoveredFromLatest: boolean }> = [];
+    if (storedJobId) candidates.push({ jobId: storedJobId, discoveredFromLatest: false });
+
+    try {
+        const latestResponse = await fetcher(`${backendUrl}/latest-job`);
+        if (latestResponse.ok) {
+            const latest = await latestResponse.json() as { job_id?: unknown };
+            if (
+                typeof latest.job_id === 'string'
+                && latest.job_id.length > 0
+                && latest.job_id !== storedJobId
+            ) {
+                candidates.push({ jobId: latest.job_id, discoveredFromLatest: true });
+            }
+        }
+    } catch {
+        // A stored job can still reconnect while latest-job is temporarily unavailable.
+    }
+
+    for (const candidate of candidates) {
+        try {
+            const statusResponse = await fetcher(`${backendUrl}/status/${candidate.jobId}`);
+            if (!statusResponse.ok) continue;
+            const record = await statusResponse.json() as JobStatusRecord;
+            if (record.status === 'running' && Array.isArray(record.steps)) {
+                return { ...candidate, record };
+            }
+        } catch {
+            // Try the next candidate; polling will retry if neither is reachable.
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
Implements the runtime/UI work tracked by [den-sq/sam_parity#38](https://github.com/den-sq/sam_parity/issues/38) and [ChengLabResearch/ouroboros_autoseg_plugin#41](https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/issues/41), following [den-sq/sam_parity#31](https://github.com/den-sq/sam_parity/issues/31).

- reports monotonic frame-derived progress through a Tokio channel for transferring, inference, and saving
- replaces raw phase indexes with typed phases and records phase-specific failures
- restores running jobs from persisted IDs or `/latest-job`, including fresh clients and stale-ID fallback
- deterministically drains progress tasks and removes staged frames on success or failure
- covers a configured positive `hotstart_delay`, delayed/burst callbacks, and reconnect before the first inference callback

Verification:
- `cargo test -p ouroboros-autoseg-plugin-backend --lib` (77 passed)
- `npm test` (4 passed)
- `npm run build`
- `npm run lint -- --no-warn-ignored`

Dependency note: `vitest` is the only direct package added for the reconnect tests. `magic-string` is pulled transitively by Vitest, while `vite-plugin-static-copy` was already a direct development dependency before this PR.
