### PR TITLE
Enable cuDNN in the production CUDA backend

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   REGISTRY_IMAGE: ghcr.io/chenglabresearch/ouroboros-autoseg-backend
+  CUDA_CANDLE_FEATURES: cuda,cudnn
 
 concurrency:
   group: backend-images-${{ github.event.pull_request.number || github.ref }}
@@ -304,6 +305,7 @@ jobs:
           build-args: |
             CUDA_BUILDER_IMAGE=${{ env.CUDA_BUILDER_IMAGE }}
             CUDA_RUNTIME_IMAGE=${{ env.CUDA_RUNTIME_IMAGE }}
+            CANDLE_FEATURES=${{ env.CUDA_CANDLE_FEATURES }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.title=Ouroboros autoseg backend (CUDA candidate)
@@ -328,6 +330,7 @@ jobs:
           build-args: |
             CUDA_BUILDER_IMAGE=${{ env.CUDA_BUILDER_IMAGE }}
             CUDA_RUNTIME_IMAGE=${{ env.CUDA_RUNTIME_IMAGE }}
+            CANDLE_FEATURES=${{ env.CUDA_CANDLE_FEATURES }}
           cache-from: |
             type=registry,ref=${{ env.CANONICAL_CACHE }}
 
@@ -352,6 +355,34 @@ jobs:
           }
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           printf 'CUDA candidate: `%s` (`%s`)\n' "${CANDIDATE_IMAGE}" "${digest}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Verify CUDA and cuDNN compile capabilities
+        shell: bash
+        env:
+          CUDA_DIGEST: ${{ steps.resolve.outputs.digest }}
+          CAN_PUBLISH: ${{ needs.prepare.outputs.can_publish }}
+          LOCAL_IMAGE: ouroboros-autoseg-backend:cuda-${{ needs.prepare.outputs.cuda_fingerprint }}
+        run: |
+          set -euo pipefail
+          image="${LOCAL_IMAGE}"
+          if [[ "${CAN_PUBLISH}" == "true" ]]; then
+            image="${REGISTRY_IMAGE}@${CUDA_DIGEST}"
+          fi
+
+          docker run --rm \
+            --entrypoint /bin/sh \
+            "${image}" \
+            -ceu '
+              test "${OUROBOROS_COMPILED_FEATURES}" = "cuda,cudnn"
+              test "${OUROBOROS_COMPILED_CUDA}" = "true"
+              test "${OUROBOROS_COMPILED_CUDNN}" = "true"
+              linkage="$(ldd /usr/local/bin/ouroboros-autoseg-plugin-backend)"
+              printf "%s\n" "${linkage}"
+              printf "%s\n" "${linkage}" | grep -Eq "libcudnn[.]so([.][0-9]+)* => /"
+              ! printf "%s\n" "${linkage}" | grep -Eq "libcudnn[.]so([.][0-9]+)* => not found"
+            '
+          printf 'Hosted CUDA gate passed for `%s`: `cuda,cudnn` compiled and cuDNN resolves.\n' \
+            "${image}" >> "${GITHUB_STEP_SUMMARY}"
 
   record-candidates:
     name: Record Candidate Images
@@ -449,6 +480,18 @@ jobs:
             exit 1
           }
 
+          gpu_certification="${REGISTRY_IMAGE}:gpu-certified-${CUDA_DIGEST#sha256:}"
+          if ! certified_cuda="$(docker buildx imagetools inspect \
+            "${gpu_certification}" --format '{{.Manifest.Digest}}' 2>/dev/null)"; then
+            echo "CUDA candidate ${REGISTRY_IMAGE}@${CUDA_DIGEST} has not passed the exact-digest GPU gate." >&2
+            echo "Run backend/scripts/certify_cuda_candidate_gpu.sh against that digest, then rerun this workflow." >&2
+            exit 1
+          fi
+          [[ "${certified_cuda}" == "${CUDA_DIGEST}" ]] || {
+            echo "GPU certification marker changed: expected ${CUDA_DIGEST}, found ${certified_cuda}" >&2
+            exit 1
+          }
+
           docker buildx imagetools create \
             --tag "${REGISTRY_IMAGE}:sha-${GITHUB_SHA}" \
             "${REGISTRY_IMAGE}@${CPU_DIGEST}"
@@ -462,11 +505,16 @@ jobs:
             --arg cuda_fingerprint "${{ needs.prepare.outputs.cuda_fingerprint }}" \
             --arg cpu_digest "${CPU_DIGEST}" \
             --arg cuda_digest "${CUDA_DIGEST}" \
+            --arg gpu_certification "${gpu_certification}" \
             '{
               schemaVersion: 1,
               commit: $commit,
               cpu: {fingerprint: $cpu_fingerprint, digest: $cpu_digest},
-              cuda: {fingerprint: $cuda_fingerprint, digest: $cuda_digest}
+              cuda: {
+                fingerprint: $cuda_fingerprint,
+                digest: $cuda_digest,
+                gpuCertification: $gpu_certification
+              }
             }' > "${RUNNER_TEMP}/backend-images.json"
 
           printf 'Certified main images\n\n- CPU: `%s@%s`\n- CUDA: `%s@%s`\n' \

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
 
     env:
-      OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG: v0.4.0-beta.2-ci
+      OUROBOROS_AUTOSEG_PLUGIN_RELEASE_TAG: v0.4.0-beta.3-ci
 
     steps:
       - name: Check out Git repository

--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ The GPU compose files use a CUDA-specific Docker target:
 - `backend/compose.gpu.yml` for packaged GPU backends
 - `backend/compose.gpu.dev.yml` for local GPU development
 
-Those compose files select the `cuda-runtime` Docker target and pass `CANDLE_FEATURES=cuda`, which forwards the plugin crate's `cuda` feature to the Candle dependencies. Building these images requires an NVIDIA-capable Docker environment with the NVIDIA container toolkit available.
+Those compose files select the `cuda-runtime` Docker target and pass the
+canonical `CANDLE_FEATURES=cuda,cudnn` feature set to the Candle dependencies.
+The target uses matching CUDA 12.4.1 cuDNN development and runtime bases and
+reports `cuda=true cudnn=true` in its startup log. Building or running these
+images requires an NVIDIA-capable Docker environment with the NVIDIA container
+toolkit available.
 
 ### Registry Backend Images
 
@@ -114,6 +119,28 @@ target, and the `-cuda` tags use the CUDA runtime target. The existing
 `backend/compose.yml` remains the local-build fallback.
 `backend/compose.registry.yml` is an opt-in compose file that accepts a prebuilt
 immutable image through `OUROBOROS_AUTOSEG_BACKEND_IMAGE`.
+
+CUDA certification has two gates against the same candidate digest. Hosted CI
+checks the declared `cuda,cudnn` capabilities and verifies that the backend's
+ELF dependencies resolve the cuDNN runtime without initializing a GPU. The
+checkpoint-backed encoder gate runs on a GPU host and must not rebuild:
+
+```bash
+BACKEND_IMAGE=ghcr.io/chenglabresearch/ouroboros-autoseg-backend@sha256:<digest> \
+INPUT_STACK=/path/to/straightened-stack.tif \
+CHECKPOINT_PATH=/path/to/checkpoint_3D.pt \
+  backend/scripts/certify_cuda_candidate_gpu.sh
+```
+
+After the smoke passes, the script records a digest-specific
+`gpu-certified-<digest>` registry marker. The `main` workflow refuses to create
+the immutable `sha-<commit>-cuda` tag unless that marker resolves to the exact
+candidate digest. If the GPU gate happens after the merge build, rerun the
+failed workflow; it reuses the existing candidate instead of compiling again.
+Publishing the marker requires a prior `docker login ghcr.io` with package
+write access. The smoke's `ARTIFACT_DIR` retains the exact image reference,
+compiled features, revisions, telemetry, bounded backend log, and validated
+output.
 
 ### `package.json`
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Tagged releases publish two preinstallable plugin artifacts:
 
 The current production beta pin for Ouroboros package builds is:
 
-- tag: `v0.4.0-beta.2`
-- CPU asset: `auto-segmentation-v0.4.0-beta.2-cpu.zip`
-- CUDA asset: `auto-segmentation-v0.4.0-beta.2-cuda.zip`
-- CPU backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta.2`
-- CUDA backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta.2-cuda`
+- tag: `v0.4.0-beta.3`
+- CPU asset: `auto-segmentation-v0.4.0-beta.3-cpu.zip`
+- CUDA asset: `auto-segmentation-v0.4.0-beta.3-cuda.zip`
+- CPU backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta.3`
+- CUDA backend image: `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:v0.4.0-beta.3-cuda`
 
-The beta.2 backend is pinned to Candle SAM3 commit
+The beta.3 backend is pinned to Candle SAM3 commit
 `c0400c6513c21655828bb92633cc190a3501a6f6`.
 
 Both archives unpack to the normal Ouroboros plugin folder layout, including

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 ARG CPU_BUILDER_IMAGE=rust:1.88-slim-bookworm
 ARG CPU_RUNTIME_IMAGE=debian:bookworm-slim
-ARG CUDA_BUILDER_IMAGE=nvidia/cuda:12.4.1-devel-ubuntu22.04
-ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.4.1-runtime-ubuntu22.04
+ARG CUDA_BUILDER_IMAGE=nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+ARG CUDA_RUNTIME_IMAGE=nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
 
 # ── Stage 1: build the Rust backend for CPU runtimes ─────────────────────────
 # Rust 1.88+ is required by the locked image dependency; it also supports edition 2024 manifests.
@@ -77,11 +77,13 @@ RUN git clone https://github.com/den-sq/candle_sam3.git candle_sam3_main \
     && git -C candle_sam3_main checkout "${CANDLE_SAM3_COMMIT}"
 
 WORKDIR /build/plugin/backend
-ARG CANDLE_FEATURES=cuda
+ARG CANDLE_FEATURES=cuda,cudnn
 ARG CUDA_COMPUTE_CAP=75
 ENV CUDA_COMPUTE_CAP=${CUDA_COMPUTE_CAP}
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir -p src \
+RUN test "${CANDLE_FEATURES}" = "cuda,cudnn" \
+    || { echo "CANDLE_FEATURES must equal the canonical cuda,cudnn feature set" >&2; exit 1; } \
+    && mkdir -p src \
     && printf 'fn main() {}\n' > src/main.rs \
     && printf '' > src/lib.rs \
     && cargo build --release --locked --features "${CANDLE_FEATURES}" \
@@ -112,6 +114,14 @@ CMD ["/usr/local/bin/ouroboros-autoseg-plugin-backend"]
 # ── Stage 4: CUDA runtime image ──────────────────────────────────────────────
 FROM ${CUDA_RUNTIME_IMAGE} AS cuda-runtime
 
+ARG CANDLE_FEATURES=cuda,cudnn
+ENV OUROBOROS_COMPILED_FEATURES=${CANDLE_FEATURES} \
+    OUROBOROS_COMPILED_CUDA=true \
+    OUROBOROS_COMPILED_CUDNN=true
+LABEL io.ouroboros.backend.compiled.features=${CANDLE_FEATURES} \
+      io.ouroboros.backend.compiled.cuda="true" \
+      io.ouroboros.backend.compiled.cudnn="true"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3 \
@@ -123,4 +133,4 @@ COPY --from=cuda-builder \
 
 EXPOSE 8686
 
-CMD ["/usr/local/bin/ouroboros-autoseg-plugin-backend"]
+CMD ["/bin/sh", "-c", "printf '%s\\n' 'backend compiled capabilities: cuda=true cudnn=true features=cuda,cudnn' >&2; exec /usr/local/bin/ouroboros-autoseg-plugin-backend"]

--- a/backend/compose.gpu.dev.yml
+++ b/backend/compose.gpu.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: cuda-runtime
       args:
-        CANDLE_FEATURES: cuda
+        CANDLE_FEATURES: cuda,cudnn
         CUDA_COMPUTE_CAP: 75
     ports:
       - "8686:8686"

--- a/backend/compose.gpu.yml
+++ b/backend/compose.gpu.yml
@@ -4,8 +4,8 @@ services:
       context: .
       target: cuda-runtime
       args:
-        # Enable CUDA feature forwarding into Candle during the Docker build.
-        CANDLE_FEATURES: cuda
+        # Enable the canonical CUDA/cuDNN feature set during the Docker build.
+        CANDLE_FEATURES: cuda,cudnn
         # Docker build cannot see the GPU; default to Quadro RTX 5000/Turing.
         CUDA_COMPUTE_CAP: 75
     ports:

--- a/backend/docs/candle2_old_pin_baseline.md
+++ b/backend/docs/candle2_old_pin_baseline.md
@@ -31,7 +31,9 @@ separate frame-derived progress work remains in `den-sq/sam_parity#38`.
 
 ## Reproduction
 
-Build the fixed CUDA control:
+Check out the recorded plugin revision before building; this command preserves
+the historical CUDA-without-cuDNN feature configuration intentionally and is
+not the current production configuration:
 
 ```bash
 docker build -f backend/Dockerfile --target cuda-runtime \

--- a/backend/scripts/biological_video_smoke_gpu.sh
+++ b/backend/scripts/biological_video_smoke_gpu.sh
@@ -18,6 +18,7 @@ Usage:
 Common options:
   BUILD_IMAGE=0                 Use BACKEND_IMAGE instead of building this checkout.
   BACKEND_IMAGE=name:tag         CUDA backend image to build/run.
+  REQUIRE_IMAGE_DIGEST=1        Require BACKEND_IMAGE to end in @sha256:<digest>.
   CUDA_COMPUTE_CAP=75            CUDA compute capability used for the local image build.
   CHECKPOINT_PATH=/path/model.pt Use an existing Medical SAM3 3D checkpoint.
   CHECKPOINT_URL=https://...     Override the default checkpoint_3D.pt URL.
@@ -152,6 +153,7 @@ INPUT_STACK="$(resolve_path "${INPUT_STACK}")"
 
 BACKEND_IMAGE="${BACKEND_IMAGE:-${DEFAULT_IMAGE}}"
 BUILD_IMAGE="${BUILD_IMAGE:-1}"
+REQUIRE_IMAGE_DIGEST="${REQUIRE_IMAGE_DIGEST:-0}"
 CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-75}"
 CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT:-c0400c6513c21655828bb92633cc190a3501a6f6}"
 PLUGIN_GIT_SHA="${PLUGIN_GIT_SHA:-$(git -C "${BACKEND_DIR}/.." rev-parse HEAD)}"
@@ -223,15 +225,36 @@ if [[ "${BUILD_IMAGE}" != "0" ]]; then
   docker build \
     -f "${BACKEND_DIR}/Dockerfile" \
     --target cuda-runtime \
-    --build-arg CANDLE_FEATURES=cuda \
+    --build-arg CANDLE_FEATURES=cuda,cudnn \
     --build-arg CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP}" \
     --build-arg CANDLE_SAM3_COMMIT="${CANDLE_SAM3_COMMIT}" \
     -t "${BACKEND_IMAGE}" \
     "${BACKEND_DIR}"
 else
-  docker image inspect "${BACKEND_IMAGE}" >/dev/null 2>&1 \
-    || die "Docker image not found or Docker is not accessible: ${BACKEND_IMAGE}"
+  if [[ "${REQUIRE_IMAGE_DIGEST}" == "1" && ! "${BACKEND_IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+    die "Certification requires BACKEND_IMAGE to use an exact @sha256 digest: ${BACKEND_IMAGE}"
+  fi
+  if ! docker image inspect "${BACKEND_IMAGE}" >/dev/null 2>&1; then
+    log "Pulling prebuilt CUDA backend image: ${BACKEND_IMAGE}"
+    docker pull "${BACKEND_IMAGE}" >/dev/null \
+      || die "Unable to pull prebuilt Docker image: ${BACKEND_IMAGE}"
+  fi
 fi
+
+log "Verifying compiled CUDA/cuDNN capabilities and runtime linkage"
+docker run --rm \
+  --entrypoint /bin/sh \
+  "${BACKEND_IMAGE}" \
+  -ceu '
+    test "${OUROBOROS_COMPILED_FEATURES}" = "cuda,cudnn"
+    test "${OUROBOROS_COMPILED_CUDA}" = "true"
+    test "${OUROBOROS_COMPILED_CUDNN}" = "true"
+    linkage="$(ldd /usr/local/bin/ouroboros-autoseg-plugin-backend)"
+    printf "%s\n" "${linkage}"
+    printf "%s\n" "${linkage}" | grep -Eq "libcudnn[.]so([.][0-9]+)* => /"
+    ! printf "%s\n" "${linkage}" | grep -Eq "libcudnn[.]so([.][0-9]+)* => not found"
+  ' >/dev/null \
+  || die "CUDA image does not prove the canonical cuda,cudnn build and resolved cuDNN runtime"
 
 docker volume create "${VOLUME_NAME}" >/dev/null
 if [[ "${REUSE_STAGED_CHECKPOINT}" == "1" ]]; then
@@ -253,7 +276,9 @@ plugin_dirty=${PLUGIN_DIRTY}
 candle_sha=${CANDLE_SAM3_COMMIT}
 input_sha256=$(sha256sum "${INPUT_STACK}" | awk '{print $1}')
 checkpoint_sha256=${CHECKPOINT_SHA256}
+image_reference=${BACKEND_IMAGE}
 image_id=$(docker image inspect --format '{{.Id}}' "${BACKEND_IMAGE}")
+compiled_features=$(docker run --rm --entrypoint /bin/sh "${BACKEND_IMAGE}" -c 'printf %s "${OUROBOROS_COMPILED_FEATURES:-unknown}"')
 cuda_compute_cap=${CUDA_COMPUTE_CAP}
 cuda_device_ordinal=${CUDA_DEVICE_ORDINAL}
 sam3_video_state_profile=${SAM3_VIDEO_STATE_PROFILE}
@@ -406,6 +431,9 @@ grep -F "plugin_sha=${PLUGIN_GIT_SHA}" "${ARTIFACT_DIR}/backend.log" >/dev/null 
   || die "Backend log does not contain the expected plugin SHA"
 grep -F "candle_sha=${CANDLE_SAM3_COMMIT}" "${ARTIFACT_DIR}/backend.log" >/dev/null \
   || die "Backend log does not contain the expected Candle SHA"
+grep -F 'backend compiled capabilities: cuda=true cudnn=true features=cuda,cudnn' \
+  "${ARTIFACT_DIR}/backend.log" >/dev/null \
+  || die "Backend log does not report the compiled CUDA/cuDNN capabilities"
 
 log "Verifying output in Docker volume"
 docker run --rm \

--- a/backend/scripts/certify_cuda_candidate_gpu.sh
+++ b/backend/scripts/certify_cuda_candidate_gpu.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Certify an exact CUDA candidate digest with the checkpoint-backed GPU smoke.
+
+Usage:
+  BACKEND_IMAGE=ghcr.io/chenglabresearch/ouroboros-autoseg-backend@sha256:<digest> \
+  INPUT_STACK=/path/to/straightened-stack.tif \
+    backend/scripts/certify_cuda_candidate_gpu.sh
+
+The smoke always runs with BUILD_IMAGE=0. After it passes, the script records
+the exact digest as gpu-certified-<digest> in the same registry repository so
+the main workflow can promote it without rebuilding. Set
+PUBLISH_GPU_CERTIFICATION=0 to run the gate without publishing that marker.
+All biological_video_smoke_gpu.sh environment controls remain available.
+USAGE
+}
+
+die() {
+  printf '[certify] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+BACKEND_IMAGE="${BACKEND_IMAGE:-}"
+[[ -n "${BACKEND_IMAGE}" ]] || {
+  usage
+  exit 2
+}
+[[ "${BACKEND_IMAGE}" =~ @sha256:([0-9a-f]{64})$ ]] \
+  || die "BACKEND_IMAGE must identify an exact @sha256 digest"
+digest_hex="${BASH_REMATCH[1]}"
+[[ -n "${INPUT_STACK:-}" ]] || die "INPUT_STACK is required"
+image_without_digest="${BACKEND_IMAGE%@sha256:*}"
+image_name="${image_without_digest##*/}"
+if [[ "${image_name}" == *:* ]]; then
+  image_repository="${image_without_digest%:*}"
+else
+  image_repository="${image_without_digest}"
+fi
+canonical_image="${image_repository}@sha256:${digest_hex}"
+
+BUILD_IMAGE=0 \
+REQUIRE_IMAGE_DIGEST=1 \
+BACKEND_IMAGE="${canonical_image}" \
+  "${SCRIPT_DIR}/biological_video_smoke_gpu.sh"
+
+if [[ "${PUBLISH_GPU_CERTIFICATION:-1}" == "1" ]]; then
+  command -v docker >/dev/null 2>&1 || die "Missing required command: docker"
+  certification_tag="${image_repository}:gpu-certified-${digest_hex}"
+  printf '[certify] Recording passed digest as %s\n' "${certification_tag}"
+  docker buildx imagetools create \
+    --tag "${certification_tag}" \
+    "${canonical_image}"
+  recorded_digest="$(docker buildx imagetools inspect \
+    "${certification_tag}" --format '{{.Manifest.Digest}}')"
+  [[ "${recorded_digest}" == "sha256:${digest_hex}" ]] \
+    || die "Certification marker resolved to ${recorded_digest}, expected sha256:${digest_hex}"
+  printf '[certify] GPU certification recorded for %s\n' "${canonical_image}"
+else
+  printf '[certify] GPU smoke passed; certification marker publication was disabled\n'
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "auto-segmentation",
-	"version": "0.4.0-beta.2",
+	"version": "0.4.0-beta.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "auto-segmentation",
-			"version": "0.4.0-beta.2",
+			"version": "0.4.0-beta.3",
 			"dependencies": {
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"index": "./index.html",
 	"dockerCompose": "./compose.yml",
 	"private": true,
-	"version": "0.4.0-beta.2",
+	"version": "0.4.0-beta.3",
 	"packageManager": "npm@11.19.0",
 	"engines": {
 		"node": ">=24",


### PR DESCRIPTION
## Summary

- compile the production CUDA backend with the canonical `cuda,cudnn` feature set
- use matching CUDA 12.4.1 cuDNN development and runtime base images
- align Docker, Compose, CI, and the biological GPU smoke configuration
- assert the declared capabilities and resolved `libcudnn` linkage on hosted CI
- require the checkpoint-backed GPU smoke to pull an exact digest with `BUILD_IMAGE=0`
- record a digest-specific GPU certification marker and block `main` promotion until it matches

This is the CUDA correction portion of #54, following the build-once architecture merged in #55. The target-aware fingerprint remains unchanged for CPU, so PR CI should perform only the one intentional cold CUDA compilation.

## Certification order

1. PR CI builds and publishes the immutable CUDA candidate.
2. Run `backend/scripts/certify_cuda_candidate_gpu.sh` against that exact digest on the GPU host.
3. The passing smoke records `gpu-certified-<digest>` in GHCR.
4. After merge, `main` reuses the candidate and promotes it only if that marker resolves to the same digest.

If the GPU gate is recorded after merge, rerunning the failed `main` workflow reuses the existing candidate rather than rebuilding it.

## Validation

- `npm test` — 10 tests passed
- `npm run lint`
- shell syntax checks for both GPU smoke scripts
- workflow YAML parse
- `docker buildx build --check -f backend/Dockerfile backend`
- build-fingerprint tests — 6 passed
- explicit before/after fingerprint comparison: CPU unchanged, CUDA changed
- `git diff --check`

No local CUDA image build was run; the PR candidate is the single intentional cold CUDA build.

Closes #54
