### PR TITLE
Decouple GPU smoke from main image promotion

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -1,4 +1,4 @@
-name: Build and Certify Backend Images
+name: Build and Verify Backend Images
 
 on:
   pull_request:
@@ -440,8 +440,8 @@ jobs:
           path: ${{ runner.temp }}/backend-candidates.json
           if-no-files-found: error
 
-  certify-main:
-    name: Certify Main Commit Images
+  promote-main:
+    name: Promote Main Commit Images
     if: needs.prepare.outputs.is_main == 'true'
     needs: [prepare, cpu, cuda]
     runs-on: ubuntu-latest
@@ -480,18 +480,6 @@ jobs:
             exit 1
           }
 
-          gpu_certification="${REGISTRY_IMAGE}:gpu-certified-${CUDA_DIGEST#sha256:}"
-          if ! certified_cuda="$(docker buildx imagetools inspect \
-            "${gpu_certification}" --format '{{.Manifest.Digest}}' 2>/dev/null)"; then
-            echo "CUDA candidate ${REGISTRY_IMAGE}@${CUDA_DIGEST} has not passed the exact-digest GPU gate." >&2
-            echo "Run backend/scripts/certify_cuda_candidate_gpu.sh against that digest, then rerun this workflow." >&2
-            exit 1
-          fi
-          [[ "${certified_cuda}" == "${CUDA_DIGEST}" ]] || {
-            echo "GPU certification marker changed: expected ${CUDA_DIGEST}, found ${certified_cuda}" >&2
-            exit 1
-          }
-
           docker buildx imagetools create \
             --tag "${REGISTRY_IMAGE}:sha-${GITHUB_SHA}" \
             "${REGISTRY_IMAGE}@${CPU_DIGEST}"
@@ -505,24 +493,19 @@ jobs:
             --arg cuda_fingerprint "${{ needs.prepare.outputs.cuda_fingerprint }}" \
             --arg cpu_digest "${CPU_DIGEST}" \
             --arg cuda_digest "${CUDA_DIGEST}" \
-            --arg gpu_certification "${gpu_certification}" \
             '{
               schemaVersion: 1,
               commit: $commit,
               cpu: {fingerprint: $cpu_fingerprint, digest: $cpu_digest},
-              cuda: {
-                fingerprint: $cuda_fingerprint,
-                digest: $cuda_digest,
-                gpuCertification: $gpu_certification
-              }
+              cuda: {fingerprint: $cuda_fingerprint, digest: $cuda_digest}
             }' > "${RUNNER_TEMP}/backend-images.json"
 
-          printf 'Certified main images\n\n- CPU: `%s@%s`\n- CUDA: `%s@%s`\n' \
+          printf 'Verified main images\n\n- CPU: `%s@%s`\n- CUDA: `%s@%s`\n' \
             "${REGISTRY_IMAGE}" "${CPU_DIGEST}" \
             "${REGISTRY_IMAGE}" "${CUDA_DIGEST}" \
             >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Upload certified image manifest
+      - name: Upload main image manifest
         uses: actions/upload-artifact@v7
         with:
           name: backend-images-${{ github.sha }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -106,7 +106,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve and promote certified backend images
+      - name: Resolve and promote main backend images
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
@@ -116,11 +116,11 @@ jobs:
           cuda_commit_image="${REGISTRY_IMAGE}:sha-${release_commit}-cuda"
 
           cpu_digest="$(docker buildx imagetools inspect "${cpu_commit_image}" --format '{{.Manifest.Digest}}')" || {
-            echo "No certified CPU image exists for ${release_commit}" >&2
+            echo "No verified main CPU image exists for ${release_commit}" >&2
             exit 1
           }
           cuda_digest="$(docker buildx imagetools inspect "${cuda_commit_image}" --format '{{.Manifest.Digest}}')" || {
-            echo "No certified CUDA image exists for ${release_commit}" >&2
+            echo "No verified main CUDA image exists for ${release_commit}" >&2
             exit 1
           }
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The beta.3 backend is pinned to Candle SAM3 commit
 Both archives unpack to the normal Ouroboros plugin folder layout, including
 `package.json`, `index.html`, `icon.svg`, `compose.yml`, frontend assets, and
 `plugin-release.json`. Release artifacts pin the CPU or CUDA backend by its
-certified `ghcr.io/chenglabresearch/ouroboros-autoseg-backend@sha256:...`
+verified `ghcr.io/chenglabresearch/ouroboros-autoseg-backend@sha256:...`
 digest. The CUDA artifact also includes the NVIDIA GPU device reservation.
 
 For production package preinstalls, unpack the selected artifact under
@@ -102,7 +102,7 @@ toolkit available.
 
 ### Registry Backend Images
 
-The `Build and Certify Backend Images` workflow fingerprints the actual CPU and
+The `Build and Verify Backend Images` workflow fingerprints the actual CPU and
 CUDA build inputs. Same-repository pull requests publish
 `candidate-pr-<number>-<fingerprint>` images and update the bounded canonical
 CPU/CUDA registry caches; fork pull requests only read those caches. A matching
@@ -113,17 +113,17 @@ of rerunning Cargo. Successful `main` builds publish commit tags:
 - `ghcr.io/chenglabresearch/ouroboros-autoseg-backend:sha-<commit>-cuda`
 
 Version-tag jobs verify those exact commit images, promote their manifests to
-the release tags, and build plugin archives containing the certified digests;
+the release tags, and build plugin archives containing the verified digests;
 they do not rebuild the Rust backend. The unsuffixed tags use the CPU runtime
 target, and the `-cuda` tags use the CUDA runtime target. The existing
 `backend/compose.yml` remains the local-build fallback.
 `backend/compose.registry.yml` is an opt-in compose file that accepts a prebuilt
 immutable image through `OUROBOROS_AUTOSEG_BACKEND_IMAGE`.
 
-CUDA certification has two gates against the same candidate digest. Hosted CI
-checks the declared `cuda,cudnn` capabilities and verifies that the backend's
-ELF dependencies resolve the cuDNN runtime without initializing a GPU. The
-checkpoint-backed encoder gate runs on a GPU host and must not rebuild:
+Hosted CI checks the declared `cuda,cudnn` capabilities and verifies that the
+backend's ELF dependencies resolve the cuDNN runtime without initializing a
+GPU. An optional checkpoint-backed pre-release diagnostic can exercise an
+exact image digest on a GPU host without rebuilding it:
 
 ```bash
 BACKEND_IMAGE=ghcr.io/chenglabresearch/ouroboros-autoseg-backend@sha256:<digest> \
@@ -132,15 +132,10 @@ CHECKPOINT_PATH=/path/to/checkpoint_3D.pt \
   backend/scripts/certify_cuda_candidate_gpu.sh
 ```
 
-After the smoke passes, the script records a digest-specific
-`gpu-certified-<digest>` registry marker. The `main` workflow refuses to create
-the immutable `sha-<commit>-cuda` tag unless that marker resolves to the exact
-candidate digest. If the GPU gate happens after the merge build, rerun the
-failed workflow; it reuses the existing candidate instead of compiling again.
-Publishing the marker requires a prior `docker login ghcr.io` with package
-write access. The smoke's `ARTIFACT_DIR` retains the exact image reference,
+The diagnostic is not a dependency of the `main` image workflow and does not
+write registry state. Its `ARTIFACT_DIR` retains the exact image reference,
 compiled features, revisions, telemetry, bounded backend log, and validated
-output.
+output for release review.
 
 ### `package.json`
 

--- a/backend/scripts/certify_cuda_candidate_gpu.sh
+++ b/backend/scripts/certify_cuda_candidate_gpu.sh
@@ -12,11 +12,9 @@ Usage:
   INPUT_STACK=/path/to/straightened-stack.tif \
     backend/scripts/certify_cuda_candidate_gpu.sh
 
-The smoke always runs with BUILD_IMAGE=0. After it passes, the script records
-the exact digest as gpu-certified-<digest> in the same registry repository so
-the main workflow can promote it without rebuilding. Set
-PUBLISH_GPU_CERTIFICATION=0 to run the gate without publishing that marker.
-All biological_video_smoke_gpu.sh environment controls remain available.
+The smoke always runs with BUILD_IMAGE=0 and never writes registry state. Its
+exit status and ARTIFACT_DIR are the pre-release evidence. All
+biological_video_smoke_gpu.sh environment controls remain available.
 USAGE
 }
 
@@ -37,34 +35,11 @@ BACKEND_IMAGE="${BACKEND_IMAGE:-}"
 }
 [[ "${BACKEND_IMAGE}" =~ @sha256:([0-9a-f]{64})$ ]] \
   || die "BACKEND_IMAGE must identify an exact @sha256 digest"
-digest_hex="${BASH_REMATCH[1]}"
 [[ -n "${INPUT_STACK:-}" ]] || die "INPUT_STACK is required"
-image_without_digest="${BACKEND_IMAGE%@sha256:*}"
-image_name="${image_without_digest##*/}"
-if [[ "${image_name}" == *:* ]]; then
-  image_repository="${image_without_digest%:*}"
-else
-  image_repository="${image_without_digest}"
-fi
-canonical_image="${image_repository}@sha256:${digest_hex}"
 
 BUILD_IMAGE=0 \
 REQUIRE_IMAGE_DIGEST=1 \
-BACKEND_IMAGE="${canonical_image}" \
+BACKEND_IMAGE="${BACKEND_IMAGE}" \
   "${SCRIPT_DIR}/biological_video_smoke_gpu.sh"
 
-if [[ "${PUBLISH_GPU_CERTIFICATION:-1}" == "1" ]]; then
-  command -v docker >/dev/null 2>&1 || die "Missing required command: docker"
-  certification_tag="${image_repository}:gpu-certified-${digest_hex}"
-  printf '[certify] Recording passed digest as %s\n' "${certification_tag}"
-  docker buildx imagetools create \
-    --tag "${certification_tag}" \
-    "${canonical_image}"
-  recorded_digest="$(docker buildx imagetools inspect \
-    "${certification_tag}" --format '{{.Manifest.Digest}}')"
-  [[ "${recorded_digest}" == "sha256:${digest_hex}" ]] \
-    || die "Certification marker resolved to ${recorded_digest}, expected sha256:${digest_hex}"
-  printf '[certify] GPU certification recorded for %s\n' "${canonical_image}"
-else
-  printf '[certify] GPU smoke passed; certification marker publication was disabled\n'
-fi
+printf '[certify] Exact-digest GPU smoke passed for %s\n' "${BACKEND_IMAGE}"


### PR DESCRIPTION
## Summary

- remove the out-of-band `gpu-certified-<digest>` registry marker from automatic `main` promotion
- keep deterministic candidate fingerprint/digest validation and hosted CUDA/cuDNN linkage verification
- make the exact-digest checkpoint GPU smoke an optional pre-release diagnostic that never writes registry state
- rename certification language to accurately describe hosted verification and manifest promotion

This corrects the orchestration failure introduced in #56. A normal `main` run no longer depends on a manual action that GitHub-hosted CI cannot perform. Release tags still require the exact `sha-<commit>` CPU/CUDA images and perform no backend compilation.

## Recovery behavior

After this PR merges, its `main` run can reuse the existing backend fingerprints and publish immutable commit images without the absent GPU marker that failed run [30965309300](https://github.com/ChengLabResearch/ouroboros_autoseg_plugin/actions/runs/30965309300). `v0.4.0-beta.3` should point at this hotfix merge commit after that run succeeds.

## No-rebuild evidence

No backend source, Cargo input, Dockerfile, feature set, or base image changes in this patch. Fixed-digest fingerprint comparison remains:

- CPU: `aa1bb87e4a82637943d9d3a0102fac5526baa90845fb78fa28be429ede3c3104`
- CUDA: `038e9153b909e36c6c1dce2e780bb83dec3f7cdd4989bdded65a7093ec296dc0`

## Validation

- `npm test` — 10 tests passed
- `npm run lint`
- `npm run build:release`
- `npm run validate:release`
- both workflow YAML files parsed
- GPU shell scripts passed `bash -n`
- obsolete marker terms are absent from workflows, docs, and scripts
- `git diff --check`
